### PR TITLE
feat: user management dashboard analytics and Chart.js visualizations

### DIFF
--- a/src/app/core/model/dashboard.model.ts
+++ b/src/app/core/model/dashboard.model.ts
@@ -42,15 +42,41 @@ export interface ApiManagementDashboardResponse {
   refreshAfterSeconds: number;
 }
 
-export interface UserManagementDashboardSummary {
+/** Grouped analytics sections (management users, future app users, …). */
+export interface UserManagementDashboardAnalytics {
+  managementUsers: ManagementUserAnalytics | null;
+}
+
+export interface ManagementUserAnalytics {
+  analyticsKey?: string;
+  summary?: ManagementUserAnalyticsSummary;
+  charts?: ManagementUserAnalyticsCharts;
+}
+
+export interface ManagementUserAnalyticsSummary {
   totalUsers: number;
   activeUsers: number;
+  inactiveUsers: number;
+  newUsersLast30Days: number;
+}
+
+export interface ManagementUserAnalyticsCharts {
+  growthTrend: GrowthTrendChart;
+  monthlyRegistrations: MonthlyActivityChart;
+  statusDistribution: StatusDistributionChart;
+  topDepartments: LabeledCountsChart;
+  topRoles: LabeledCountsChart;
+}
+
+export interface LabeledCountsChart {
+  labels: string[];
+  counts: number[];
 }
 
 /** User management dashboard (user-centric metrics). */
 export interface UserManagementDashboardResponse {
   kind: 'user-management';
-  summary: UserManagementDashboardSummary;
+  analytics: UserManagementDashboardAnalytics;
   timestamp: string;
   refreshAfterSeconds: number;
 }

--- a/src/app/features/dashboard/dashboard.component.html
+++ b/src/app/features/dashboard/dashboard.component.html
@@ -1,8 +1,5 @@
 <div @fadeSlideInOut class="dashboard">
   <div class="row dashboard__toolbar mb-lg">
-    <div class="col-12 col-md-6">
-      <h1 class="dashboard__title">Dashboard</h1>
-    </div>
     <div class="col-12 col-md-6 dashboard__toolbar-actions">
       @if (dashboardScopeOptions.length > 0) {
         <mat-form-field appearance="outline" class="dashboard__scope-select" subscriptSizing="dynamic">

--- a/src/app/features/dashboard/user-management-dashboard/user-management-dashboard.component.html
+++ b/src/app/features/dashboard/user-management-dashboard/user-management-dashboard.component.html
@@ -1,7 +1,9 @@
 <section class="dashboard__section">
   <h2 class="dashboard__section-title">User management</h2>
+  <p class="dashboard__section-lead">Directory users (management)</p>
+
   <div class="row">
-    <div class="col-12 col-lg-6 col-xl-4 mb-lg">
+    <div class="col-12 col-lg-6 col-xl-3 mb-lg">
       <blogsphere-info-card
         variant="primary"
         size="medium"
@@ -12,13 +14,13 @@
         >
         <div class="dashboard__card-body">
           <p class="dashboard__stat">{{ totalUsers }}</p>
-          <p class="dashboard__hint">Registered users in the system</p>
+          <p class="dashboard__hint">Accounts in the directory index</p>
         </div>
       </blogsphere-info-card>
     </div>
-    <div class="col-12 col-lg-6 col-xl-4 mb-lg">
+    <div class="col-12 col-lg-6 col-xl-3 mb-lg">
       <blogsphere-info-card
-        variant="info"
+        variant="success"
         size="medium"
         title="Active users"
         icon="verified_user"
@@ -26,8 +28,182 @@
         borderPosition="left"
         >
         <div class="dashboard__card-body">
-          <p class="dashboard__stat">{{ totalActiveUsers }}</p>
-          <p class="dashboard__hint">Users currently active</p>
+          <p class="dashboard__stat">{{ activeUsers }}</p>
+          <p class="dashboard__hint">Users marked active</p>
+        </div>
+      </blogsphere-info-card>
+    </div>
+    <div class="col-12 col-lg-6 col-xl-3 mb-lg">
+      <blogsphere-info-card
+        variant="warning"
+        size="medium"
+        title="Inactive users"
+        icon="person_off"
+        [showIcon]="true"
+        borderPosition="left"
+        >
+        <div class="dashboard__card-body">
+          <p class="dashboard__stat">{{ inactiveUsers }}</p>
+          <p class="dashboard__hint">Users marked inactive</p>
+        </div>
+      </blogsphere-info-card>
+    </div>
+    <div class="col-12 col-lg-6 col-xl-3 mb-lg">
+      <blogsphere-info-card
+        variant="info"
+        size="medium"
+        title="New (30 days)"
+        icon="person_add"
+        [showIcon]="true"
+        borderPosition="left"
+        >
+        <div class="dashboard__card-body">
+          <p class="dashboard__stat">{{ newUsersLast30Days }}</p>
+          <p class="dashboard__hint">New accounts in the last 30 days</p>
+        </div>
+      </blogsphere-info-card>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-12 mb-lg">
+      <blogsphere-info-card
+        variant="info"
+        size="medium"
+        title="Account growth (cumulative)"
+        icon="trending_up"
+        [showIcon]="true"
+        borderPosition="none"
+        >
+        <div class="dashboard__chart-container dashboard__chart-container--line">
+          @if (!chartsDataLoaded) {
+            <div class="dashboard__chart-loading">
+              <mat-progress-spinner mode="indeterminate" diameter="48" color="primary"></mat-progress-spinner>
+              <p>Loading chart data...</p>
+            </div>
+          }
+          @if (chartsDataLoaded) {
+            <canvas
+              baseChart
+              [data]="growthChartData"
+              [options]="growthChartOptions"
+              [type]="lineChartType"
+            ></canvas>
+          }
+        </div>
+      </blogsphere-info-card>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-12 col-lg-6 mb-lg">
+      <blogsphere-info-card
+        variant="primary"
+        size="medium"
+        title="Monthly registrations"
+        icon="bar_chart"
+        [showIcon]="true"
+        borderPosition="none"
+        >
+        <div class="dashboard__chart-container dashboard__chart-container--bar">
+          @if (!chartsDataLoaded) {
+            <div class="dashboard__chart-loading">
+              <mat-progress-spinner mode="indeterminate" diameter="48" color="primary"></mat-progress-spinner>
+              <p>Loading chart data...</p>
+            </div>
+          }
+          @if (chartsDataLoaded) {
+            <canvas
+              baseChart
+              [data]="monthlyChartData"
+              [options]="monthlyChartOptions"
+              [type]="barChartType"
+            ></canvas>
+          }
+        </div>
+      </blogsphere-info-card>
+    </div>
+    <div class="col-12 col-lg-6 mb-lg">
+      <blogsphere-info-card
+        variant="success"
+        size="medium"
+        title="Status distribution"
+        icon="pie_chart"
+        [showIcon]="true"
+        borderPosition="none"
+        >
+        <div class="dashboard__chart-container dashboard__chart-container--doughnut">
+          @if (!chartsDataLoaded) {
+            <div class="dashboard__chart-loading">
+              <mat-progress-spinner mode="indeterminate" diameter="48" color="primary"></mat-progress-spinner>
+              <p>Loading chart data...</p>
+            </div>
+          }
+          @if (chartsDataLoaded) {
+            <canvas
+              baseChart
+              [data]="statusChartData"
+              [options]="statusChartOptions"
+              [type]="doughnutChartType"
+            ></canvas>
+          }
+        </div>
+      </blogsphere-info-card>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-12 col-lg-6 mb-lg">
+      <blogsphere-info-card
+        variant="success"
+        size="medium"
+        title="Top departments"
+        icon="domain"
+        [showIcon]="true"
+        borderPosition="none"
+        >
+        <div class="dashboard__chart-container dashboard__chart-container--horizontal-bar">
+          @if (!chartsDataLoaded) {
+            <div class="dashboard__chart-loading">
+              <mat-progress-spinner mode="indeterminate" diameter="48" color="primary"></mat-progress-spinner>
+              <p>Loading chart data...</p>
+            </div>
+          }
+          @if (chartsDataLoaded) {
+            <canvas
+              baseChart
+              [data]="topDepartmentsChartData"
+              [options]="topDepartmentsChartOptions"
+              [type]="barChartType"
+            ></canvas>
+          }
+        </div>
+      </blogsphere-info-card>
+    </div>
+    <div class="col-12 col-lg-6 mb-lg">
+      <blogsphere-info-card
+        variant="primary"
+        size="medium"
+        title="Top roles"
+        icon="badge"
+        [showIcon]="true"
+        borderPosition="none"
+        >
+        <div class="dashboard__chart-container dashboard__chart-container--horizontal-bar">
+          @if (!chartsDataLoaded) {
+            <div class="dashboard__chart-loading">
+              <mat-progress-spinner mode="indeterminate" diameter="48" color="primary"></mat-progress-spinner>
+              <p>Loading chart data...</p>
+            </div>
+          }
+          @if (chartsDataLoaded) {
+            <canvas
+              baseChart
+              [data]="topRolesChartData"
+              [options]="topRolesChartOptions"
+              [type]="barChartType"
+            ></canvas>
+          }
         </div>
       </blogsphere-info-card>
     </div>

--- a/src/app/features/dashboard/user-management-dashboard/user-management-dashboard.component.scss
+++ b/src/app/features/dashboard/user-management-dashboard/user-management-dashboard.component.scss
@@ -37,3 +37,52 @@
   margin: 0;
   line-height: 1.4;
 }
+
+.dashboard__section-lead {
+  @include font($font-size-base, $font-weight-regular);
+  color: rgba($color-text-primary, 0.65);
+  margin: -0.5rem 0 $spacing-md;
+}
+
+.dashboard__chart-container {
+  position: relative;
+  width: 100%;
+
+  &--line {
+    height: 300px;
+  }
+
+  &--bar {
+    height: 280px;
+  }
+
+  &--doughnut {
+    height: 280px;
+    max-width: 400px;
+    margin: 0 auto;
+  }
+
+  &--horizontal-bar {
+    height: 320px;
+  }
+
+  canvas {
+    max-width: 100%;
+  }
+}
+
+.dashboard__chart-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  min-height: 200px;
+  gap: $spacing-md;
+
+  p {
+    @include font($font-size-base, $font-weight-regular);
+    color: rgba($color-text-primary, 0.6);
+    margin: 0;
+  }
+}

--- a/src/app/features/dashboard/user-management-dashboard/user-management-dashboard.component.ts
+++ b/src/app/features/dashboard/user-management-dashboard/user-management-dashboard.component.ts
@@ -1,5 +1,12 @@
 import { ChangeDetectionStrategy, Component, Input, OnChanges, SimpleChanges } from '@angular/core';
-import { UserManagementDashboardResponse } from 'src/app/core/model/dashboard.model';
+import { ChartConfiguration, ChartData, ChartType } from 'chart.js';
+import {
+  GrowthTrendChart,
+  LabeledCountsChart,
+  MonthlyActivityChart,
+  StatusDistributionChart,
+  UserManagementDashboardResponse,
+} from 'src/app/core/model/dashboard.model';
 
 @Component({
   selector: 'blogsphere-user-management-dashboard',
@@ -11,14 +18,197 @@ import { UserManagementDashboardResponse } from 'src/app/core/model/dashboard.mo
 export class UserManagementDashboardComponent implements OnChanges {
   @Input({ required: true }) summary!: UserManagementDashboardResponse;
 
+  public chartsDataLoaded = false;
+
+  public lineChartType: ChartType = 'line';
+  public barChartType: ChartType = 'bar';
+  public doughnutChartType: ChartType = 'doughnut';
+
+  public growthChartData: ChartData<'line'> = { labels: [], datasets: [] };
+  public growthChartOptions: ChartConfiguration['options'] = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: { display: true, position: 'top' },
+      title: { display: false },
+    },
+    scales: {
+      y: { beginAtZero: true },
+    },
+  };
+
+  public monthlyChartData: ChartData<'bar'> = { labels: [], datasets: [] };
+  public monthlyChartOptions: ChartConfiguration['options'] = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: { display: false },
+      title: { display: false },
+    },
+    scales: {
+      y: { beginAtZero: true },
+    },
+  };
+
+  public statusChartData: ChartData<'doughnut'> = { labels: [], datasets: [] };
+  public statusChartOptions: ChartConfiguration['options'] = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: { display: true, position: 'bottom' },
+      title: { display: false },
+    },
+  };
+
+  public topDepartmentsChartData: ChartData<'bar'> = { labels: [], datasets: [] };
+  public topDepartmentsChartOptions: ChartConfiguration['options'] = {
+    responsive: true,
+    maintainAspectRatio: false,
+    indexAxis: 'y',
+    plugins: {
+      legend: { display: false },
+      title: { display: false },
+    },
+    scales: {
+      x: { beginAtZero: true },
+    },
+  };
+
+  public topRolesChartData: ChartData<'bar'> = { labels: [], datasets: [] };
+  public topRolesChartOptions: ChartConfiguration['options'] = {
+    responsive: true,
+    maintainAspectRatio: false,
+    indexAxis: 'y',
+    plugins: {
+      legend: { display: false },
+      title: { display: false },
+    },
+    scales: {
+      x: { beginAtZero: true },
+    },
+  };
+
   public totalUsers = 0;
-  public totalActiveUsers = 0;
+  public activeUsers = 0;
+  public inactiveUsers = 0;
+  public newUsersLast30Days = 0;
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['summary']?.currentValue) {
-      const response = changes['summary'].currentValue as UserManagementDashboardResponse;
-      this.totalUsers = response.summary?.totalUsers ?? 0;
-      this.totalActiveUsers = response.summary?.activeUsers ?? 0;
+      this.applyDashboard(changes['summary'].currentValue as UserManagementDashboardResponse);
     }
+  }
+
+  private applyDashboard(response: UserManagementDashboardResponse): void {
+    const mgmt = response.analytics?.managementUsers;
+    const s = mgmt?.summary;
+
+    this.totalUsers = s?.totalUsers ?? 0;
+    this.activeUsers = s?.activeUsers ?? 0;
+    this.inactiveUsers = s?.inactiveUsers ?? 0;
+    this.newUsersLast30Days = s?.newUsersLast30Days ?? 0;
+
+    const charts = mgmt?.charts;
+    this.updateGrowthTrendChart(charts?.growthTrend);
+    this.updateMonthlyChart(charts?.monthlyRegistrations);
+    this.updateStatusChart(charts?.statusDistribution);
+    this.updateTopDepartmentsChart(charts?.topDepartments);
+    this.updateTopRolesChart(charts?.topRoles);
+
+    this.chartsDataLoaded = true;
+  }
+
+  private updateGrowthTrendChart(trend?: GrowthTrendChart): void {
+    const labels = trend?.labels ?? [];
+    const datasets = (trend?.datasets ?? []).map((dataset, index) => ({
+      data: dataset.data ?? [],
+      label: dataset.label,
+      borderColor: index === 0 ? '#0033cc' : '#0076ff',
+      backgroundColor: index === 0 ? 'rgba(0, 51, 204, 0.1)' : 'rgba(0, 118, 255, 0.1)',
+      tension: 0.4,
+      fill: true,
+    }));
+
+    this.growthChartData = { labels, datasets };
+  }
+
+  private updateMonthlyChart(monthly?: MonthlyActivityChart): void {
+    const labels = monthly?.labels ?? [];
+    const data = monthly?.counts ?? [];
+
+    this.monthlyChartData = {
+      labels,
+      datasets: [
+        {
+          data,
+          label: 'New users',
+          backgroundColor: '#0076ff',
+          hoverBackgroundColor: '#0057b8',
+        },
+      ],
+    };
+  }
+
+  private updateStatusChart(distribution?: StatusDistributionChart): void {
+    const labels = distribution?.labels ?? [];
+    const data = distribution?.counts ?? [];
+    const colors = this.getStatusColors(labels);
+
+    this.statusChartData = {
+      labels,
+      datasets: [
+        {
+          data,
+          backgroundColor: colors.bg,
+          hoverBackgroundColor: colors.hover,
+        },
+      ],
+    };
+  }
+
+  private updateTopDepartmentsChart(top?: LabeledCountsChart): void {
+    const labels = top?.labels ?? [];
+    const data = top?.counts ?? [];
+
+    this.topDepartmentsChartData = {
+      labels,
+      datasets: [
+        {
+          data,
+          label: 'Users',
+          backgroundColor: '#0d9488',
+          hoverBackgroundColor: '#0f766e',
+        },
+      ],
+    };
+  }
+
+  private updateTopRolesChart(top?: LabeledCountsChart): void {
+    const labels = top?.labels ?? [];
+    const data = top?.counts ?? [];
+
+    this.topRolesChartData = {
+      labels,
+      datasets: [
+        {
+          data,
+          label: 'Assignments',
+          backgroundColor: '#7c3aed',
+          hoverBackgroundColor: '#6d28d9',
+        },
+      ],
+    };
+  }
+
+  private getStatusColors(statuses: string[]): { bg: string[]; hover: string[] } {
+    const colorMap: Record<string, { bg: string; hover: string }> = {
+      Active: { bg: '#10b981', hover: '#059669' },
+      Inactive: { bg: '#ef4444', hover: '#dc2626' },
+    };
+
+    const bg = statuses.map((status) => colorMap[status]?.bg || '#6b7280');
+    const hover = statuses.map((status) => colorMap[status]?.hover || '#4b5563');
+
+    return { bg, hover };
   }
 }


### PR DESCRIPTION
## Summary

- Aligns the user management dashboard with an **analytics** payload (management users, summary, and chart series) instead of a flat summary object.
- Adds **KPI cards** for total, active, inactive, and new users (30 days) with clearer copy for directory-backed metrics.
- Implements **Chart.js** views for growth trend, monthly registrations, status distribution, and top departments/roles.
- Removes the redundant **Dashboard** heading from the main dashboard shell so the scoped view title stands alone.
- Adds **loading states** and SCSS for chart containers and section lead text.

## Changes

- **Models**: `dashboard.model.ts` — `UserManagementDashboardAnalytics`, `ManagementUserAnalytics`, chart/summary types; `UserManagementDashboardResponse` now uses `analytics` instead of `summary`.
- **User management dashboard**: Template, component logic (Chart.js data/options), and styles for cards and charts.
- **Dashboard shell**: Minor template cleanup (removed duplicate title).

## Notes

- Requires a BFF/API response that provides `analytics.managementUsers` with the new shape; older `summary`-only payloads will no longer match this UI contract.
- This PR replaces [#5](https://github.com/Scaler-io/Blogsphere.Management.Webapp/pull/5), which used branch `feature/auth-permission-utils` for the same commit; review should happen here on the dedicated branch.