### PR TITLE
Phase 1.5 + 2 — shell bug fixes, responsive SCSS library, status-pill & chart-card atoms, dashboard migration

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -4,7 +4,8 @@
 .app-shell {
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
+  height: 100vh;
+  overflow: hidden;
   background: var(--md-background);
 
   &__body {
@@ -17,25 +18,24 @@
   &__main {
     flex: 1 1 auto;
     min-width: 0;
+    min-height: 0;
     display: flex;
     flex-direction: column;
-    overflow: auto;
+    overflow-y: auto;
+    overflow-x: hidden;
 
     &--full {
-      // Profile page has its own shell (no sidebar / page-header)
       width: 100%;
     }
   }
 
   &__content {
     flex: 1 1 auto;
-    width: 100%;
-    max-width: $container-max;
-    margin: 0 auto;
-    padding: $page-margin-mobile;
+    @include page-container;
+    padding-block: $page-margin-mobile;
 
-    @include respond-to(md) {
-      padding: $page-margin-desktop;
+    @include desktop-up {
+      padding-block: $page-margin-desktop;
     }
   }
 

--- a/src/app/features/dashboard/api-management-dashboard/api-management-dashboard.component.html
+++ b/src/app/features/dashboard/api-management-dashboard/api-management-dashboard.component.html
@@ -1,5 +1,4 @@
 <section class="api-dashboard">
-  <!-- Hero metrics row -->
   <div class="api-dashboard__grid api-dashboard__grid--hero">
     <blogsphere-metric-card
       class="api-dashboard__metric"
@@ -41,7 +40,6 @@
     </blogsphere-metric-card>
   </div>
 
-  <!-- Quick actions row -->
   <div class="api-dashboard__grid api-dashboard__grid--actions">
     <h2 class="api-dashboard__section-title">Quick actions</h2>
     <div class="api-dashboard__actions">
@@ -69,87 +67,61 @@
     </div>
   </div>
 
-  <!-- Growth chart card -->
-  <div class="api-dashboard__chart api-dashboard__chart--wide">
-    <header class="api-dashboard__chart-header">
-      <div>
-        <span class="api-dashboard__chart-eyebrow">PERFORMANCE</span>
-        <h3 class="api-dashboard__chart-title">Growth trend</h3>
-      </div>
-      <blogsphere-segmented-control
-        [options]="growthChartRangeOptions"
-        [value]="growthChartRange"
-        size="sm"
-        tone="secondary"
-        ariaLabel="Growth chart time range"
-        (valueChange)="onGrowthRangeChange($event)"
-      />
-    </header>
-    <div class="api-dashboard__chart-body api-dashboard__chart-body--line">
-      @if (!chartsDataLoaded) {
-        <div class="api-dashboard__chart-loading">
-          <mat-progress-spinner mode="indeterminate" diameter="40" color="primary"></mat-progress-spinner>
-          <p>Loading chart data…</p>
-        </div>
-      } @else {
-        <canvas
-          baseChart
-          [data]="growthChartData"
-          [options]="growthChartOptions"
-          [type]="lineChartType"
-        ></canvas>
-      }
-    </div>
-  </div>
+  <blogsphere-chart-card
+    class="api-dashboard__chart--wide"
+    eyebrow="PERFORMANCE"
+    title="Growth trend"
+    tone="secondary"
+    [loading]="!chartsDataLoaded"
+    bodyHeight="320px"
+  >
+    <blogsphere-segmented-control
+      toolbar
+      [options]="growthChartRangeOptions"
+      [value]="growthChartRange"
+      size="sm"
+      tone="secondary"
+      ariaLabel="Growth chart time range"
+      (valueChange)="onGrowthRangeChange($event)"
+    />
+    <canvas
+      baseChart
+      [data]="growthChartData"
+      [options]="growthChartOptions"
+      [type]="lineChartType"
+    ></canvas>
+  </blogsphere-chart-card>
 
-  <!-- Side-by-side chart cards -->
   <div class="api-dashboard__grid api-dashboard__grid--charts">
-    <div class="api-dashboard__chart">
-      <header class="api-dashboard__chart-header">
-        <div>
-          <span class="api-dashboard__chart-eyebrow">DISTRIBUTION</span>
-          <h3 class="api-dashboard__chart-title">Cluster status</h3>
-        </div>
-      </header>
-      <div class="api-dashboard__chart-body api-dashboard__chart-body--doughnut">
-        @if (!chartsDataLoaded) {
-          <div class="api-dashboard__chart-loading">
-            <mat-progress-spinner mode="indeterminate" diameter="40" color="primary"></mat-progress-spinner>
-            <p>Loading chart data…</p>
-          </div>
-        } @else {
-          <canvas
-            baseChart
-            [data]="statusChartData"
-            [options]="statusChartOptions"
-            [type]="doughnutChartType"
-          ></canvas>
-        }
-      </div>
-    </div>
+    <blogsphere-chart-card
+      eyebrow="DISTRIBUTION"
+      title="Cluster status"
+      tone="secondary"
+      [loading]="!chartsDataLoaded"
+      bodyHeight="280px"
+      bodyMaxWidth="360px"
+    >
+      <canvas
+        baseChart
+        [data]="statusChartData"
+        [options]="statusChartOptions"
+        [type]="doughnutChartType"
+      ></canvas>
+    </blogsphere-chart-card>
 
-    <div class="api-dashboard__chart">
-      <header class="api-dashboard__chart-header">
-        <div>
-          <span class="api-dashboard__chart-eyebrow">ACTIVITY</span>
-          <h3 class="api-dashboard__chart-title">Monthly route activity</h3>
-        </div>
-      </header>
-      <div class="api-dashboard__chart-body api-dashboard__chart-body--bar">
-        @if (!chartsDataLoaded) {
-          <div class="api-dashboard__chart-loading">
-            <mat-progress-spinner mode="indeterminate" diameter="40" color="primary"></mat-progress-spinner>
-            <p>Loading chart data…</p>
-          </div>
-        } @else {
-          <canvas
-            baseChart
-            [data]="activityChartData"
-            [options]="activityChartOptions"
-            [type]="barChartType"
-          ></canvas>
-        }
-      </div>
-    </div>
+    <blogsphere-chart-card
+      eyebrow="ACTIVITY"
+      title="Monthly route activity"
+      tone="secondary"
+      [loading]="!chartsDataLoaded"
+      bodyHeight="280px"
+    >
+      <canvas
+        baseChart
+        [data]="activityChartData"
+        [options]="activityChartOptions"
+        [type]="barChartType"
+      ></canvas>
+    </blogsphere-chart-card>
   </div>
 </section>

--- a/src/app/features/dashboard/api-management-dashboard/api-management-dashboard.component.scss
+++ b/src/app/features/dashboard/api-management-dashboard/api-management-dashboard.component.scss
@@ -6,37 +6,25 @@
 }
 
 .api-dashboard {
-  display: flex;
-  flex-direction: column;
-  gap: $page-gutter;
+  @include section-stack($page-gutter, $page-gutter);
 
   &__grid {
     display: grid;
     gap: $page-gutter;
     grid-template-columns: 1fr;
 
-    @include respond-to(md) {
+    @include desktop-up {
       grid-template-columns: repeat(3, minmax(0, 1fr));
     }
 
-    &--hero {
-      grid-template-columns: 1fr;
-
-      @include respond-to(md) {
-        grid-template-columns: repeat(3, minmax(0, 1fr));
-      }
-    }
-
     &--actions {
-      display: flex;
-      flex-direction: column;
-      gap: $spacing-md;
+      @include stack($spacing-md);
     }
 
     &--charts {
       grid-template-columns: 1fr;
 
-      @include respond-to(lg) {
+      @include wide-up {
         grid-template-columns: minmax(0, 5fr) minmax(0, 7fr);
       }
     }
@@ -61,7 +49,7 @@
     gap: $page-gutter;
     grid-template-columns: 1fr;
 
-    @include respond-to(md) {
+    @include desktop-up {
       grid-template-columns: repeat(3, minmax(0, 1fr));
     }
   }
@@ -72,71 +60,7 @@
     margin: 0;
   }
 
-  &__chart {
-    background: var(--md-surface-container-lowest);
-    border: 1px solid var(--md-outline-variant);
-    border-radius: $border-radius-md;
-    box-shadow: var(--md-elevation-card);
-    padding: $spacing-lg;
-    display: flex;
-    flex-direction: column;
-    gap: $spacing-md;
-
-    &--wide {
-      width: 100%;
-    }
-  }
-
-  &__chart-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: $spacing-md;
-    flex-wrap: wrap;
-  }
-
-  &__chart-eyebrow {
-    @include type(label-xs);
-    color: var(--md-secondary);
-    display: block;
-  }
-
-  &__chart-title {
-    margin: 0;
-    @include type(headline-sm);
-    color: var(--md-on-surface);
-  }
-
-  &__chart-body {
-    position: relative;
+  &__chart--wide {
     width: 100%;
-
-    &--line { height: 320px; }
-    &--bar { height: 280px; }
-    &--doughnut {
-      height: 280px;
-      max-width: 360px;
-      margin: 0 auto;
-    }
-
-    canvas {
-      max-width: 100%;
-    }
-  }
-
-  &__chart-loading {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    height: 100%;
-    min-height: 200px;
-    gap: $spacing-md;
-
-    p {
-      @include type(body-sm);
-      color: var(--md-on-surface-variant);
-      margin: 0;
-    }
   }
 }

--- a/src/app/features/dashboard/chart-theme.ts
+++ b/src/app/features/dashboard/chart-theme.ts
@@ -1,16 +1,9 @@
-// ============================================================================
-// CHART THEME HELPER — reads `--md-*` CSS custom properties so Chart.js
-// datasets stay in lock-step with the SCSS / Angular Material M3 palette.
-// ============================================================================
-//
-// Why a helper:
-//  - The dashboard charts used to hardcode hex values (`#0033cc`, `#10b981`,
-//    …). After the AGL redesign every brand color lives on `:root` as
-//    `--md-*`, so Chart.js datasets read them at runtime — no recompile
-//    needed if a token changes.
-//  - SSR-safe: every helper guards against `window`/`document` being
-//    undefined (the platform check is implicit in `getComputedStyle` usage).
-//  - Each function is idempotent and cheap to call on every `ngOnChanges`.
+/**
+ * Chart theme helper — reads `--md-*` CSS custom properties so Chart.js
+ * datasets stay in lock-step with the Angular Material M3 palette.
+ * SSR-safe: every helper guards against `window` / `document` being
+ * unavailable, and each function is cheap to call from `ngOnChanges`.
+ */
 
 /**
  * Read a CSS custom property value from `:root`. Returns `fallback` when
@@ -75,8 +68,8 @@ export function getChartPalette(): ChartPalette {
     onSurfaceVariant: readCssVar('--md-on-surface-variant', '#454654'),
     error: readCssVar('--md-error', '#ba1a1a'),
     errorContainer: readCssVar('--md-error-container', '#ffdad6'),
-    success: '#10b981',
-    warning: '#f59e0b',
+    success: readCssVar('--md-status-success', '#0c9167'),
+    warning: readCssVar('--md-status-warning', '#ff8f00'),
     tertiary: readCssVar('--md-tertiary', '#202326'),
   };
 }
@@ -109,15 +102,19 @@ export function getBaseChartOptions(): {
  * color. Falls back to the secondary token for unknown statuses.
  */
 export function getStatusColor(status: string, palette: ChartPalette): { bg: string; hover: string } {
+  const successHover = readCssVar('--md-status-success', palette.success);
+  const errorHover = readCssVar('--md-status-error', palette.error);
+  const warningHover = readCssVar('--md-status-warning', palette.warning);
+
   switch (status?.toLowerCase()) {
     case 'active':
-      return { bg: palette.success, hover: '#047857' };
+      return { bg: palette.success, hover: successHover };
     case 'inactive':
     case 'failed':
-      return { bg: palette.error, hover: '#7e0007' };
+      return { bg: palette.error, hover: errorHover };
     case 'pending':
     case 'paused':
-      return { bg: palette.warning, hover: '#b45309' };
+      return { bg: palette.warning, hover: warningHover };
     case 'archived':
       return { bg: palette.tertiary, hover: palette.onSurface };
     default:

--- a/src/app/features/dashboard/dashboard.component.scss
+++ b/src/app/features/dashboard/dashboard.component.scss
@@ -6,9 +6,7 @@
 }
 
 .dashboard {
-  display: flex;
-  flex-direction: column;
-  gap: $page-gutter;
+  @include section-stack($page-gutter, $page-gutter);
 
   &__toolbar {
     display: flex;
@@ -27,11 +25,9 @@
   }
 
   &__page-loading {
-    display: flex;
-    flex-direction: column;
+    @include stack($spacing-md);
     align-items: center;
     justify-content: center;
-    gap: $spacing-md;
     min-height: 240px;
 
     p {

--- a/src/app/features/dashboard/dashboard.module.ts
+++ b/src/app/features/dashboard/dashboard.module.ts
@@ -27,6 +27,7 @@ import { SegmentedControlModule } from 'src/app/shared/components/segmented-cont
 import { ProgressBarModule } from 'src/app/shared/components/progress-bar/progress-bar.module';
 import { StatTileModule } from 'src/app/shared/components/stat-tile/stat-tile.module';
 import { IconButtonModule } from 'src/app/shared/components/icon-button/icon-button.module';
+import { ChartCardModule } from 'src/app/shared/components/chart-card/chart-card.module';
 import { DASHBOARD_SERVICE_TOKEN } from 'src/app/core/services/interface/dashboard-service.interface';
 import { DashboardService } from 'src/app/core/services/dashboard.service';
 
@@ -52,6 +53,7 @@ import { DashboardService } from 'src/app/core/services/dashboard.service';
     ProgressBarModule,
     StatTileModule,
     IconButtonModule,
+    ChartCardModule,
     BaseChartDirective,
   ],
   providers: [

--- a/src/app/features/dashboard/user-management-dashboard/user-management-dashboard.component.html
+++ b/src/app/features/dashboard/user-management-dashboard/user-management-dashboard.component.html
@@ -1,5 +1,4 @@
 <section class="users-dashboard">
-  <!-- Hero metric grid -->
   <div class="users-dashboard__grid users-dashboard__grid--metrics">
     <blogsphere-metric-card
       label="TOTAL USERS"
@@ -43,130 +42,84 @@
     />
   </div>
 
-  <!-- Growth chart card (full width) -->
-  <div class="users-dashboard__chart users-dashboard__chart--wide">
-    <header class="users-dashboard__chart-header">
-      <div>
-        <span class="users-dashboard__chart-eyebrow">PERFORMANCE</span>
-        <h3 class="users-dashboard__chart-title">Account growth (cumulative)</h3>
-      </div>
-    </header>
-    <div class="users-dashboard__chart-body users-dashboard__chart-body--line">
-      @if (!chartsDataLoaded) {
-        <div class="users-dashboard__chart-loading">
-          <mat-progress-spinner mode="indeterminate" diameter="40" color="primary"></mat-progress-spinner>
-          <p>Loading chart data…</p>
-        </div>
-      } @else {
-        <canvas
-          baseChart
-          [data]="growthChartData"
-          [options]="growthChartOptions"
-          [type]="lineChartType"
-        ></canvas>
-      }
-    </div>
+  <blogsphere-chart-card
+    class="users-dashboard__chart--wide"
+    eyebrow="PERFORMANCE"
+    title="Account growth (cumulative)"
+    tone="secondary"
+    [loading]="!chartsDataLoaded"
+    bodyHeight="320px"
+  >
+    <canvas
+      baseChart
+      [data]="growthChartData"
+      [options]="growthChartOptions"
+      [type]="lineChartType"
+    ></canvas>
+  </blogsphere-chart-card>
+
+  <div class="users-dashboard__grid users-dashboard__grid--two-up">
+    <blogsphere-chart-card
+      eyebrow="REGISTRATIONS"
+      title="Monthly registrations"
+      tone="secondary"
+      [loading]="!chartsDataLoaded"
+      bodyHeight="280px"
+    >
+      <canvas
+        baseChart
+        [data]="monthlyChartData"
+        [options]="monthlyChartOptions"
+        [type]="barChartType"
+      ></canvas>
+    </blogsphere-chart-card>
+
+    <blogsphere-chart-card
+      eyebrow="DISTRIBUTION"
+      title="Status distribution"
+      tone="secondary"
+      [loading]="!chartsDataLoaded"
+      bodyHeight="280px"
+      bodyMaxWidth="360px"
+    >
+      <canvas
+        baseChart
+        [data]="statusChartData"
+        [options]="statusChartOptions"
+        [type]="doughnutChartType"
+      ></canvas>
+    </blogsphere-chart-card>
   </div>
 
-  <!-- Two-up: monthly bar + status doughnut -->
   <div class="users-dashboard__grid users-dashboard__grid--two-up">
-    <div class="users-dashboard__chart">
-      <header class="users-dashboard__chart-header">
-        <div>
-          <span class="users-dashboard__chart-eyebrow">REGISTRATIONS</span>
-          <h3 class="users-dashboard__chart-title">Monthly registrations</h3>
-        </div>
-      </header>
-      <div class="users-dashboard__chart-body users-dashboard__chart-body--bar">
-        @if (!chartsDataLoaded) {
-          <div class="users-dashboard__chart-loading">
-            <mat-progress-spinner mode="indeterminate" diameter="40" color="primary"></mat-progress-spinner>
-            <p>Loading chart data…</p>
-          </div>
-        } @else {
-          <canvas
-            baseChart
-            [data]="monthlyChartData"
-            [options]="monthlyChartOptions"
-            [type]="barChartType"
-          ></canvas>
-        }
-      </div>
-    </div>
+    <blogsphere-chart-card
+      eyebrow="SEGMENTS"
+      title="Top departments"
+      tone="secondary"
+      [loading]="!chartsDataLoaded"
+      bodyHeight="280px"
+    >
+      <canvas
+        baseChart
+        [data]="topDepartmentsChartData"
+        [options]="topDepartmentsChartOptions"
+        [type]="barChartType"
+      ></canvas>
+    </blogsphere-chart-card>
 
-    <div class="users-dashboard__chart">
-      <header class="users-dashboard__chart-header">
-        <div>
-          <span class="users-dashboard__chart-eyebrow">DISTRIBUTION</span>
-          <h3 class="users-dashboard__chart-title">Status distribution</h3>
-        </div>
-      </header>
-      <div class="users-dashboard__chart-body users-dashboard__chart-body--doughnut">
-        @if (!chartsDataLoaded) {
-          <div class="users-dashboard__chart-loading">
-            <mat-progress-spinner mode="indeterminate" diameter="40" color="primary"></mat-progress-spinner>
-            <p>Loading chart data…</p>
-          </div>
-        } @else {
-          <canvas
-            baseChart
-            [data]="statusChartData"
-            [options]="statusChartOptions"
-            [type]="doughnutChartType"
-          ></canvas>
-        }
-      </div>
-    </div>
-  </div>
-
-  <!-- Top departments + top roles -->
-  <div class="users-dashboard__grid users-dashboard__grid--two-up">
-    <div class="users-dashboard__chart">
-      <header class="users-dashboard__chart-header">
-        <div>
-          <span class="users-dashboard__chart-eyebrow">SEGMENTS</span>
-          <h3 class="users-dashboard__chart-title">Top departments</h3>
-        </div>
-      </header>
-      <div class="users-dashboard__chart-body users-dashboard__chart-body--horizontal-bar">
-        @if (!chartsDataLoaded) {
-          <div class="users-dashboard__chart-loading">
-            <mat-progress-spinner mode="indeterminate" diameter="40" color="primary"></mat-progress-spinner>
-            <p>Loading chart data…</p>
-          </div>
-        } @else {
-          <canvas
-            baseChart
-            [data]="topDepartmentsChartData"
-            [options]="topDepartmentsChartOptions"
-            [type]="barChartType"
-          ></canvas>
-        }
-      </div>
-    </div>
-
-    <div class="users-dashboard__chart">
-      <header class="users-dashboard__chart-header">
-        <div>
-          <span class="users-dashboard__chart-eyebrow">ROLES</span>
-          <h3 class="users-dashboard__chart-title">Top roles</h3>
-        </div>
-      </header>
-      <div class="users-dashboard__chart-body users-dashboard__chart-body--horizontal-bar">
-        @if (!chartsDataLoaded) {
-          <div class="users-dashboard__chart-loading">
-            <mat-progress-spinner mode="indeterminate" diameter="40" color="primary"></mat-progress-spinner>
-            <p>Loading chart data…</p>
-          </div>
-        } @else {
-          <canvas
-            baseChart
-            [data]="topRolesChartData"
-            [options]="topRolesChartOptions"
-            [type]="barChartType"
-          ></canvas>
-        }
-      </div>
-    </div>
+    <blogsphere-chart-card
+      eyebrow="ROLES"
+      title="Top roles"
+      tone="secondary"
+      [loading]="!chartsDataLoaded"
+      bodyHeight="280px"
+    >
+      <canvas
+        baseChart
+        [data]="topRolesChartData"
+        [options]="topRolesChartOptions"
+        [type]="barChartType"
+      ></canvas>
+    </blogsphere-chart-card>
   </div>
 </section>

--- a/src/app/features/dashboard/user-management-dashboard/user-management-dashboard.component.scss
+++ b/src/app/features/dashboard/user-management-dashboard/user-management-dashboard.component.scss
@@ -6,9 +6,7 @@
 }
 
 .users-dashboard {
-  display: flex;
-  flex-direction: column;
-  gap: $page-gutter;
+  @include section-stack($page-gutter, $page-gutter);
 
   &__grid {
     display: grid;
@@ -16,85 +14,22 @@
     grid-template-columns: 1fr;
 
     &--metrics {
-      @include respond-to(sm) {
+      @include tablet-up {
         grid-template-columns: repeat(2, minmax(0, 1fr));
       }
-      @include respond-to(lg) {
+      @include wide-up {
         grid-template-columns: repeat(4, minmax(0, 1fr));
       }
     }
 
     &--two-up {
-      @include respond-to(lg) {
+      @include wide-up {
         grid-template-columns: repeat(2, minmax(0, 1fr));
       }
     }
   }
 
-  &__chart {
-    background: var(--md-surface-container-lowest);
-    border: 1px solid var(--md-outline-variant);
-    border-radius: $border-radius-md;
-    box-shadow: var(--md-elevation-card);
-    padding: $spacing-lg;
-    display: flex;
-    flex-direction: column;
-    gap: $spacing-md;
-
-    &--wide {
-      width: 100%;
-    }
-  }
-
-  &__chart-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: $spacing-md;
-    flex-wrap: wrap;
-  }
-
-  &__chart-eyebrow {
-    @include type(label-xs);
-    color: var(--md-secondary);
-    display: block;
-  }
-
-  &__chart-title {
-    margin: 0;
-    @include type(headline-sm);
-    color: var(--md-on-surface);
-  }
-
-  &__chart-body {
-    position: relative;
+  &__chart--wide {
     width: 100%;
-
-    &--line { height: 320px; }
-    &--bar { height: 280px; }
-    &--doughnut {
-      height: 280px;
-      max-width: 360px;
-      margin: 0 auto;
-    }
-    &--horizontal-bar { height: 320px; }
-
-    canvas { max-width: 100%; }
-  }
-
-  &__chart-loading {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    height: 100%;
-    min-height: 200px;
-    gap: $spacing-md;
-
-    p {
-      @include type(body-sm);
-      color: var(--md-on-surface-variant);
-      margin: 0;
-    }
   }
 }

--- a/src/app/features/sidebar/sidebar-expandable-nav-item/sidebar-expandable-nav-item.component.html
+++ b/src/app/features/sidebar/sidebar-expandable-nav-item/sidebar-expandable-nav-item.component.html
@@ -4,6 +4,8 @@
     class="sidebar-expandable__header"
     [class.sidebar-expandable__header--group-active]="isGroupActive()"
     [attr.aria-expanded]="expanded"
+    [matTooltip]="collapsed ? label : ''"
+    matTooltipPosition="right"
     (click)="headerClick.emit()"
   >
     <span class="material-symbols-rounded sidebar-expandable__icon" aria-hidden="true">{{ headerIcon }}</span>
@@ -13,14 +15,20 @@
     </span>
   </button>
 
-  <div class="sidebar-expandable__submenu" [class.sidebar-expandable__submenu--open]="expanded" role="list">
-    @for (item of submenuItems; track item.routerLink) {
-      <blogsphere-sidebar-submenu-link
-        [link]="item.routerLink"
-        [icon]="item.icon"
-        [label]="item.label"
-        (navigate)="submenuNavigate.emit()"
-      />
-    }
+  <div
+    class="sidebar-expandable__submenu"
+    [class.sidebar-expandable__submenu--open]="expanded && !collapsed"
+    [attr.aria-hidden]="!expanded || collapsed"
+  >
+    <div class="sidebar-expandable__submenu-inner" role="list">
+      @for (item of submenuItems; track item.routerLink) {
+        <blogsphere-sidebar-submenu-link
+          [link]="item.routerLink"
+          [icon]="item.icon"
+          [label]="item.label"
+          (navigate)="submenuNavigate.emit()"
+        />
+      }
+    </div>
   </div>
 </div>

--- a/src/app/features/sidebar/sidebar-expandable-nav-item/sidebar-expandable-nav-item.component.scss
+++ b/src/app/features/sidebar/sidebar-expandable-nav-item/sidebar-expandable-nav-item.component.scss
@@ -5,10 +5,32 @@
   display: block;
 }
 
+:host(.host--collapsed) {
+  .sidebar-expandable__header {
+    justify-content: center;
+    padding: $spacing-sm;
+  }
+
+  .sidebar-expandable__label,
+  .sidebar-expandable__chevron {
+    display: none;
+  }
+}
+
+:host(.host--collapsed):hover {
+  .sidebar-expandable__header {
+    justify-content: flex-start;
+    padding: $spacing-sm $spacing-md;
+  }
+
+  .sidebar-expandable__label,
+  .sidebar-expandable__chevron {
+    display: inline-block;
+  }
+}
+
 .sidebar-expandable {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
+  @include stack(2px);
 
   &__header {
     display: flex;
@@ -23,16 +45,16 @@
     color: var(--md-on-surface-variant);
     font-family: $font-family-body;
     text-align: left;
-    transition: background-color 200ms ease, color 200ms ease;
+    transition: background-color 200ms ease, color 200ms ease, padding 200ms ease;
+
+    @include hover-surface;
 
     &:hover {
-      background: var(--md-surface-container);
       color: var(--md-on-surface);
     }
 
     &:focus-visible {
-      outline: 2px solid var(--md-primary);
-      outline-offset: 2px;
+      @include focus-ring;
     }
 
     &--group-active {
@@ -69,18 +91,25 @@
   }
 
   &__submenu {
-    display: grid;
-    grid-template-rows: 0fr;
-    overflow: hidden;
-    transition: grid-template-rows 0.25s ease-in-out;
+    @include collapse-rows;
     padding-left: $spacing-lg;
 
     &--open {
       grid-template-rows: 1fr;
     }
+  }
 
-    > * {
-      min-height: 0;
+  &__submenu-inner {
+    @include stack(2px);
+    min-height: 0;
+    overflow: hidden;
+    opacity: 0;
+    padding-top: 0;
+    transition: opacity 0.2s ease-in-out, padding-top 0.2s ease-in-out;
+
+    .sidebar-expandable__submenu--open & {
+      opacity: 1;
+      padding-top: $spacing-xs;
     }
   }
 }

--- a/src/app/features/sidebar/sidebar-expandable-nav-item/sidebar-expandable-nav-item.component.ts
+++ b/src/app/features/sidebar/sidebar-expandable-nav-item/sidebar-expandable-nav-item.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, HostBinding, Input, Output } from '@angular/core';
 import { Router } from '@angular/router';
 
 export interface SidebarSubmenuItem {
@@ -15,6 +15,7 @@ export interface SidebarSubmenuItem {
 })
 export class SidebarExpandableNavItemComponent {
   @Input() expanded = false;
+  @Input() collapsed = false;
   @Input() label = '';
   @Input() headerIcon = 'api';
   @Input() submenuItems: SidebarSubmenuItem[] = [];
@@ -22,6 +23,11 @@ export class SidebarExpandableNavItemComponent {
   @Output() submenuNavigate = new EventEmitter<void>();
 
   constructor(private router: Router) {}
+
+  @HostBinding('class.host--collapsed')
+  get isCollapsedHost(): boolean {
+    return this.collapsed;
+  }
 
   isGroupActive(): boolean {
     return this.submenuItems.some(i => this.router.isActive(i.routerLink, false));

--- a/src/app/features/sidebar/sidebar-expandable-nav-item/sidebar-expandable-nav-item.module.ts
+++ b/src/app/features/sidebar/sidebar-expandable-nav-item/sidebar-expandable-nav-item.module.ts
@@ -2,12 +2,13 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { MatRippleModule } from '@angular/material/core';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { SidebarExpandableNavItemComponent } from './sidebar-expandable-nav-item.component';
 import { SidebarSubmenuLinkModule } from '../sidebar-submenu-link/sidebar-submenu-link.module';
 
 @NgModule({
   declarations: [SidebarExpandableNavItemComponent],
-  imports: [CommonModule, RouterModule, MatRippleModule, SidebarSubmenuLinkModule],
+  imports: [CommonModule, RouterModule, MatRippleModule, MatTooltipModule, SidebarSubmenuLinkModule],
   exports: [SidebarExpandableNavItemComponent],
 })
 export class SidebarExpandableNavItemModule {}

--- a/src/app/features/sidebar/sidebar-nav-link/sidebar-nav-link.component.html
+++ b/src/app/features/sidebar/sidebar-nav-link/sidebar-nav-link.component.html
@@ -3,6 +3,8 @@
   matRipple
   [routerLink]="link"
   [routerLinkActive]="'sidebar-nav-link--active'"
+  [matTooltip]="collapsed ? label : ''"
+  matTooltipPosition="right"
   (click)="navigate.emit()"
   role="listitem"
 >

--- a/src/app/features/sidebar/sidebar-nav-link/sidebar-nav-link.component.scss
+++ b/src/app/features/sidebar/sidebar-nav-link/sidebar-nav-link.component.scss
@@ -5,6 +5,26 @@
   display: block;
 }
 
+:host(.host--collapsed) {
+  .sidebar-nav-link {
+    justify-content: center;
+    padding: $spacing-sm;
+  }
+
+  .sidebar-nav-link__label {
+    display: none;
+  }
+}
+
+:host(.host--collapsed):hover .sidebar-nav-link {
+  justify-content: flex-start;
+  padding: $spacing-sm $spacing-md;
+}
+
+:host(.host--collapsed):hover .sidebar-nav-link__label {
+  display: block;
+}
+
 .sidebar-nav-link {
   display: flex;
   align-items: center;
@@ -14,18 +34,18 @@
   color: var(--md-on-surface-variant);
   text-decoration: none;
   cursor: pointer;
-  transition: background-color 200ms ease, color 200ms ease;
+  transition: background-color 200ms ease, color 200ms ease, padding 200ms ease;
   font-family: $font-family-body;
 
+  @include hover-surface;
+
   &:hover {
-    background: var(--md-surface-container);
     color: var(--md-on-surface);
     text-decoration: none;
   }
 
   &:focus-visible {
-    outline: 2px solid var(--md-primary);
-    outline-offset: 2px;
+    @include focus-ring;
   }
 
   &__icon {

--- a/src/app/features/sidebar/sidebar-nav-link/sidebar-nav-link.component.ts
+++ b/src/app/features/sidebar/sidebar-nav-link/sidebar-nav-link.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, HostBinding, Input, Output } from '@angular/core';
 
 @Component({
   selector: 'blogsphere-sidebar-nav-link',
@@ -10,5 +10,11 @@ export class SidebarNavLinkComponent {
   @Input() link = '';
   @Input() icon = '';
   @Input() label = '';
+  @Input() collapsed = false;
   @Output() navigate = new EventEmitter<void>();
+
+  @HostBinding('class.host--collapsed')
+  get isCollapsedHost(): boolean {
+    return this.collapsed;
+  }
 }

--- a/src/app/features/sidebar/sidebar-nav-link/sidebar-nav-link.module.ts
+++ b/src/app/features/sidebar/sidebar-nav-link/sidebar-nav-link.module.ts
@@ -2,11 +2,12 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { MatRippleModule } from '@angular/material/core';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { SidebarNavLinkComponent } from './sidebar-nav-link.component';
 
 @NgModule({
   declarations: [SidebarNavLinkComponent],
-  imports: [CommonModule, RouterModule, MatRippleModule],
+  imports: [CommonModule, RouterModule, MatRippleModule, MatTooltipModule],
   exports: [SidebarNavLinkComponent],
 })
 export class SidebarNavLinkModule {}

--- a/src/app/features/sidebar/sidebar.component.html
+++ b/src/app/features/sidebar/sidebar.component.html
@@ -16,6 +16,7 @@
         link="/dashboard"
         icon="dashboard"
         label="Dashboard"
+        [collapsed]="isCollapsedRail"
         (navigate)="handleSidenavItemClick()"
       />
       @if (canAccessSystemSettings$ | async) {
@@ -23,10 +24,12 @@
           link="/subscription"
           icon="subscriptions"
           label="Subscription manager"
+          [collapsed]="isCollapsedRail"
           (navigate)="handleSidenavItemClick()"
         />
         <blogsphere-sidebar-expandable-nav-item
           [expanded]="subMenuList.apiManager"
+          [collapsed]="isCollapsedRail"
           [submenuItems]="apiManagerSubmenuItems"
           [label]="'Api manager'"
           headerIcon="api"
@@ -37,6 +40,7 @@
       @if (canAccessUserManagement$ | async) {
         <blogsphere-sidebar-expandable-nav-item
           [expanded]="subMenuList.userManagement"
+          [collapsed]="isCollapsedRail"
           [submenuItems]="userManagementSubmenuItems"
           [label]="'User manager'"
           headerIcon="people"

--- a/src/app/features/sidebar/sidebar.component.scss
+++ b/src/app/features/sidebar/sidebar.component.scss
@@ -10,49 +10,64 @@
 
 :host(.host--collapsed) {
   width: $sidebar-collapsed-width;
+
+  &:hover {
+    width: $sidebar-width;
+
+    .sidenav {
+      width: $sidebar-width;
+    }
+  }
+}
+
+@include mobile-only {
+  :host,
+  :host(.host--collapsed),
+  :host(.host--mobile-hidden) {
+    width: 0;
+  }
 }
 
 .sidenav {
-  position: sticky;
-  top: $topbar-height;
   width: $sidebar-width;
-  height: calc(100vh - #{$topbar-height});
+  height: 100%;
   background: var(--md-surface-container-lowest);
   border-right: 1px solid var(--md-outline-variant);
-  overflow-y: auto;
-  overflow-x: hidden;
+  display: flex;
+  flex-direction: column;
   transition: width 0.25s ease-in-out, transform 0.25s ease-in-out;
 
   &--collapsed {
     width: $sidebar-collapsed-width;
   }
 
-  // Mobile overlay behavior
-  @include respond-to(xs) {
+  @include mobile-only {
     position: fixed;
     top: $topbar-height;
     left: 0;
-    height: calc(100vh - #{$topbar-height});
-    z-index: $z-index-fixed;
+    height: calc(100% - #{$topbar-height});
+    width: $sidebar-width;
+    z-index: $z-index-modal;
     transform: translateX(-100%);
     box-shadow: var(--md-elevation-overlay);
   }
 
   &--mobile-open {
-    @include respond-to(xs) {
+    @include mobile-only {
       transform: translateX(0);
     }
   }
 
   &__nav {
-    height: 100%;
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
     padding: $spacing-md $spacing-sm;
   }
 
   &__list {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
+    @include stack(2px);
     list-style: none;
     margin: 0;
     padding: 0;

--- a/src/app/features/sidebar/sidebar.component.ts
+++ b/src/app/features/sidebar/sidebar.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, HostBinding, OnDestroy, OnInit } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
 import { AppPermission } from 'src/app/core/auth/permissions.constants';
@@ -46,6 +46,16 @@ export class SidebarComponent implements OnInit, OnDestroy {
 
   constructor(private store: Store<AppState>) {}
 
+  @HostBinding('class.host--collapsed')
+  get isCollapsedRail(): boolean {
+    return !this.isMobileView && !this.isSidenavExpanded;
+  }
+
+  @HostBinding('class.host--mobile-hidden')
+  get isMobileHidden(): boolean {
+    return this.isMobileView && !this.isSidenavExpanded;
+  }
+
   ngOnInit(): void {
     this.subscriptions.sidenavToggleState = this.store
       .select(getSidenavToggleState)
@@ -63,8 +73,11 @@ export class SidebarComponent implements OnInit, OnDestroy {
     this.subscriptions.mobileViewState = this.store
       .select(selectMobileViewState)
       .subscribe(state => {
-        if (state) {
-          this.isMobileView = state;
+        const wasMobile = this.isMobileView;
+        this.isMobileView = state;
+        // Auto-close the sidenav only on the desktop → mobile transition
+        // (when the user resizes down while the rail is expanded).
+        if (!wasMobile && state && this.isSidenavExpanded) {
           this.store.dispatch(new ToggleSideNav());
         }
       });

--- a/src/app/shared/components/chart-card/chart-card.component.html
+++ b/src/app/shared/components/chart-card/chart-card.component.html
@@ -1,0 +1,35 @@
+<section class="chart-card" [class.chart-card--loading]="loading">
+  <header class="chart-card__header">
+    <div class="chart-card__heading">
+      <span
+        *ngIf="eyebrow"
+        class="chart-card__eyebrow"
+        [class.chart-card__eyebrow--primary]="tone === 'primary'"
+        [class.chart-card__eyebrow--secondary]="tone === 'secondary'"
+      >{{ eyebrow }}</span>
+      <h3 class="chart-card__title">{{ title }}</h3>
+      <p *ngIf="subtitle" class="chart-card__subtitle">{{ subtitle }}</p>
+    </div>
+    <div class="chart-card__toolbar">
+      <ng-content select="[toolbar]"></ng-content>
+    </div>
+  </header>
+
+  <div
+    class="chart-card__body"
+    [style.height]="bodyHeight"
+    [style.max-width]="bodyMaxWidth"
+    [style.margin-inline]="bodyMaxWidth ? 'auto' : null"
+  >
+    <ng-container *ngIf="!loading; else loadingBlock">
+      <ng-content></ng-content>
+    </ng-container>
+    <ng-template #loadingBlock>
+      <ng-content select="[loading]"></ng-content>
+      <div class="chart-card__loading" *ngIf="loading">
+        <span class="chart-card__spinner" aria-hidden="true"></span>
+        <p class="chart-card__loading-label">{{ loadingLabel }}</p>
+      </div>
+    </ng-template>
+  </div>
+</section>

--- a/src/app/shared/components/chart-card/chart-card.component.scss
+++ b/src/app/shared/components/chart-card/chart-card.component.scss
@@ -1,0 +1,80 @@
+@use 'sass-utils/variables' as *;
+@use 'sass-utils/mixins' as *;
+
+:host {
+  display: block;
+}
+
+.chart-card {
+  @include md-card($border-radius-md, $spacing-lg);
+  @include stack($spacing-md);
+
+  &__header {
+    @include row-between($spacing-md, wrap, flex-start);
+  }
+
+  &__heading {
+    @include stack($spacing-xs);
+    min-width: 0;
+    flex: 1 1 auto;
+  }
+
+  &__eyebrow {
+    @include eyebrow-label;
+    color: var(--md-on-surface-variant);
+    display: block;
+
+    &--primary   { color: var(--md-primary); }
+    &--secondary { color: var(--md-secondary); }
+  }
+
+  &__title {
+    margin: 0;
+    @include type(headline-sm);
+    color: var(--md-on-surface);
+  }
+
+  &__subtitle {
+    margin: 0;
+    @include type(body-sm);
+    color: var(--md-on-surface-variant);
+  }
+
+  &__toolbar:empty {
+    display: none;
+  }
+
+  &__toolbar {
+    flex-shrink: 0;
+  }
+
+  &__body {
+    position: relative;
+    width: 100%;
+
+    canvas {
+      max-width: 100%;
+    }
+  }
+
+  &__loading {
+    @include stack($spacing-md);
+    align-items: center;
+    justify-content: center;
+    min-height: 200px;
+  }
+
+  &__loading-label {
+    @include type(body-sm);
+    color: var(--md-on-surface-variant);
+    margin: 0;
+  }
+
+  &__spinner {
+    @include inline-spinner(1.5rem, var(--md-primary));
+  }
+
+  &--loading .chart-card__body {
+    min-height: 200px;
+  }
+}

--- a/src/app/shared/components/chart-card/chart-card.component.ts
+++ b/src/app/shared/components/chart-card/chart-card.component.ts
@@ -1,0 +1,40 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+
+export type ChartCardTone = 'neutral' | 'primary' | 'secondary';
+
+/**
+ * Surface for visualisations (line / bar / doughnut / etc).
+ *
+ * Slots:
+ *  - default          : the chart canvas / svg body.
+ *  - `[toolbar]`      : trailing toolbar shown next to the title (segmented
+ *                       controls, date range pickers, etc).
+ *  - `[loading]`      : custom loading placeholder (otherwise the built-in
+ *                       spinner block is rendered when `loading=true`).
+ *
+ * Inputs:
+ *  - eyebrow          : small uppercase tag above the title.
+ *  - title            : main heading (required for accessibility).
+ *  - subtitle         : optional muted helper text under the title.
+ *  - tone             : `neutral` | `primary` | `secondary` — drives eyebrow color.
+ *  - loading          : when true, hides the body and renders the loading block.
+ *  - bodyHeight       : optional CSS value for the body height (e.g. `'320px'`).
+ *  - bodyMaxWidth     : optional CSS value to center small charts (e.g. doughnut).
+ */
+@Component({
+  selector: 'blogsphere-chart-card',
+  templateUrl: './chart-card.component.html',
+  styleUrls: ['./chart-card.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: false,
+})
+export class ChartCardComponent {
+  @Input() eyebrow?: string;
+  @Input() title = '';
+  @Input() subtitle?: string;
+  @Input() tone: ChartCardTone = 'neutral';
+  @Input() loading = false;
+  @Input() bodyHeight?: string;
+  @Input() bodyMaxWidth?: string;
+  @Input() loadingLabel = 'Loading chart…';
+}

--- a/src/app/shared/components/chart-card/chart-card.module.ts
+++ b/src/app/shared/components/chart-card/chart-card.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ChartCardComponent } from './chart-card.component';
+
+@NgModule({
+  declarations: [ChartCardComponent],
+  imports: [CommonModule],
+  exports: [ChartCardComponent],
+})
+export class ChartCardModule {}

--- a/src/app/shared/components/icon-button/icon-button.component.scss
+++ b/src/app/shared/components/icon-button/icon-button.component.scss
@@ -28,15 +28,13 @@
   }
 
   &:focus-visible {
-    outline: 2px solid var(--md-primary);
-    outline-offset: 2px;
+    @include focus-ring;
   }
 
   &:disabled,
   &--disabled,
   &--loading {
-    cursor: not-allowed;
-    opacity: 0.6;
+    @include disabled-state;
     transform: none;
   }
 
@@ -51,7 +49,7 @@
     border-radius: 50%;
     border: 2px solid currentColor;
     border-top-color: transparent;
-    animation: blogsphere-icon-button-spin 600ms linear infinite;
+    animation: blogsphere-inline-spin 600ms linear infinite;
   }
 
   &__badge {
@@ -71,7 +69,6 @@
     box-shadow: 0 0 0 2px var(--md-surface);
   }
 
-  // -------- sizes --------
   &--size-sm {
     width: 2rem;
     height: 2rem;
@@ -90,7 +87,6 @@
     font-size: 1.5rem;
   }
 
-  // -------- variants & tones --------
   &--variant-ghost {
     background: transparent;
     border-color: transparent;
@@ -184,8 +180,4 @@
       color: var(--md-error);
     }
   }
-}
-
-@keyframes blogsphere-icon-button-spin {
-  to { transform: rotate(360deg); }
 }

--- a/src/app/shared/components/metric-card/metric-card.component.html
+++ b/src/app/shared/components/metric-card/metric-card.component.html
@@ -17,10 +17,13 @@
   <p class="metric-card__value">{{ formattedValue }}</p>
 
   <div *ngIf="delta || subtext" class="metric-card__meta">
-    <span *ngIf="delta" class="metric-card__delta" [ngClass]="deltaToneClass">
-      <span class="material-symbols-rounded metric-card__delta-icon" aria-hidden="true">{{ deltaIcon }}</span>
-      <span class="metric-card__delta-value">{{ delta.value }}</span>
-    </span>
+    <blogsphere-status-pill
+      *ngIf="delta"
+      [tone]="deltaPillTone"
+      [icon]="deltaIcon"
+      [label]="delta.value"
+      size="sm"
+    ></blogsphere-status-pill>
     <span *ngIf="subtext" class="metric-card__subtext">{{ subtext }}</span>
   </div>
 

--- a/src/app/shared/components/metric-card/metric-card.component.scss
+++ b/src/app/shared/components/metric-card/metric-card.component.scss
@@ -7,23 +7,15 @@
 }
 
 .metric-card {
+  @include md-card($border-radius-md, $spacing-lg);
+  @include md-card-hover(1px);
   position: relative;
   display: flex;
   flex-direction: column;
   gap: $spacing-md;
   height: 100%;
-  padding: $spacing-lg;
-  border-radius: $border-radius-md;
-  background: var(--md-surface-container-lowest);
-  box-shadow: var(--md-elevation-card);
-  border: 1px solid var(--md-outline-variant);
   overflow: hidden;
   transition: box-shadow 200ms ease, transform 200ms ease, border-color 200ms ease;
-
-  &:hover {
-    box-shadow: var(--md-elevation-card-hover);
-    transform: translateY(-1px);
-  }
 
   &__accent {
     position: absolute;
@@ -31,10 +23,10 @@
     pointer-events: none;
   }
 
-  &--accent-tone-primary  .metric-card__accent { background: var(--md-primary); }
+  &--accent-tone-primary   .metric-card__accent { background: var(--md-primary); }
   &--accent-tone-secondary .metric-card__accent { background: var(--md-secondary); }
-  &--accent-tone-error    .metric-card__accent { background: var(--md-error); }
-  &--accent-tone-success  .metric-card__accent { background: #10b981; }
+  &--accent-tone-error     .metric-card__accent { background: var(--md-error); }
+  &--accent-tone-success   .metric-card__accent { background: var(--md-status-success); }
 
   &--accent-left .metric-card__accent {
     top: 0;
@@ -67,14 +59,11 @@
   }
 
   &__label {
-    @include type(label-xs);
-    color: var(--md-secondary);
+    @include eyebrow-label(var(--md-secondary));
   }
 
   &__top-slot {
-    display: flex;
-    align-items: center;
-    gap: $spacing-xs;
+    @include cluster($spacing-xs);
   }
 
   &__icon {
@@ -94,41 +83,7 @@
   }
 
   &__meta {
-    display: flex;
-    align-items: center;
-    gap: $spacing-sm;
-    flex-wrap: wrap;
-  }
-
-  &__delta {
-    display: inline-flex;
-    align-items: center;
-    gap: $spacing-xs;
-    padding: 0.125rem $spacing-sm;
-    border-radius: $border-radius-full;
-    font-size: $type-label-sm-size;
-    font-weight: $font-weight-medium;
-    line-height: $type-label-sm-line;
-  }
-
-  &__delta-icon {
-    font-size: 1rem;
-    line-height: 1;
-  }
-
-  &__delta--positive {
-    background: rgba(16, 185, 129, 0.12);
-    color: #047857;
-  }
-
-  &__delta--negative {
-    background: rgba(186, 26, 26, 0.12);
-    color: var(--md-error);
-  }
-
-  &__delta--neutral {
-    background: var(--md-surface-container);
-    color: var(--md-on-surface-variant);
+    @include cluster($spacing-sm);
   }
 
   &__subtext {

--- a/src/app/shared/components/metric-card/metric-card.component.ts
+++ b/src/app/shared/components/metric-card/metric-card.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { StatusPillTone } from '../status-pill/status-pill.component';
 
 export type MetricDeltaDirection = 'up' | 'down' | 'flat';
 export type MetricDeltaTone = 'positive' | 'negative' | 'neutral';
@@ -109,7 +110,14 @@ export class MetricCardComponent {
     }
   }
 
-  get deltaToneClass(): string {
-    return `metric-card__delta--${this.delta?.tone ?? 'neutral'}`;
+  get deltaPillTone(): StatusPillTone {
+    switch (this.delta?.tone ?? 'neutral') {
+      case 'positive':
+        return 'success';
+      case 'negative':
+        return 'error';
+      default:
+        return 'neutral';
+    }
   }
 }

--- a/src/app/shared/components/metric-card/metric-card.module.ts
+++ b/src/app/shared/components/metric-card/metric-card.module.ts
@@ -1,10 +1,11 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MetricCardComponent } from './metric-card.component';
+import { StatusPillModule } from '../status-pill/status-pill.module';
 
 @NgModule({
   declarations: [MetricCardComponent],
-  imports: [CommonModule],
+  imports: [CommonModule, StatusPillModule],
   exports: [MetricCardComponent],
 })
 export class MetricCardModule {}

--- a/src/app/shared/components/navbar/navbar.component.scss
+++ b/src/app/shared/components/navbar/navbar.component.scss
@@ -1,6 +1,11 @@
 @use 'sass-utils/variables' as *;
 @use 'sass-utils/mixins' as *;
 
+:host {
+  display: block;
+  flex-shrink: 0;
+}
+
 .topbar {
   display: flex;
   align-items: center;
@@ -9,11 +14,8 @@
   padding: 0 $page-margin-mobile;
   background: var(--md-surface-container-lowest);
   border-bottom: 1px solid var(--md-outline-variant);
-  position: sticky;
-  top: 0;
-  z-index: $z-index-sticky;
 
-  @include respond-to(md) {
+  @include desktop-up {
     padding: 0 $page-margin-desktop;
   }
 

--- a/src/app/shared/components/page-header/page-header.component.scss
+++ b/src/app/shared/components/page-header/page-header.component.scss
@@ -38,44 +38,16 @@
 
   &__title-text {
     margin: 0;
-    @include type(headline-lg);
+    @include type(headline-lg-mobile);
     color: var(--md-on-surface);
 
-    @include respond-to(sm) {
-      @include type(headline-lg-mobile);
+    @include desktop-up {
+      @include type(headline-lg);
     }
   }
 
   &__breadcrumb {
     @include type(label-sm);
     color: var(--md-on-surface-variant);
-
-    ::ng-deep .xng-breadcrumb-root {
-      display: flex;
-      align-items: center;
-      gap: $spacing-xs;
-    }
-
-    ::ng-deep .xng-breadcrumb-item {
-      display: inline-flex;
-      align-items: center;
-    }
-
-    ::ng-deep .xng-breadcrumb-link {
-      color: var(--md-on-surface-variant);
-      text-decoration: none;
-
-      &:hover { color: var(--md-secondary); text-decoration: underline; }
-    }
-
-    ::ng-deep .xng-breadcrumb-trail {
-      color: var(--md-on-surface);
-      font-weight: $font-weight-medium;
-    }
-
-    ::ng-deep .xng-breadcrumb-separator {
-      color: var(--md-outline);
-      margin: 0 $spacing-xs;
-    }
   }
 }

--- a/src/app/shared/components/progress-bar/progress-bar.component.scss
+++ b/src/app/shared/components/progress-bar/progress-bar.component.scss
@@ -49,26 +49,22 @@
     color: var(--md-on-surface-variant);
   }
 
-  // -------- sizes --------
   &--size-sm .progress-bar__track { height: 0.25rem; }
   &--size-md .progress-bar__track { height: 0.5rem; }
   &--size-lg .progress-bar__track { height: 0.75rem; }
 
-  // -------- tones --------
   &--tone-primary   .progress-bar__fill { background: var(--md-primary); }
   &--tone-secondary .progress-bar__fill { background: var(--md-secondary); }
-  &--tone-success   .progress-bar__fill { background: #10b981; }
-  &--tone-warning   .progress-bar__fill { background: #f59e0b; }
+  &--tone-success   .progress-bar__fill { background: var(--md-status-success); }
+  &--tone-warning   .progress-bar__fill { background: var(--md-status-warning); }
   &--tone-error     .progress-bar__fill { background: var(--md-error); }
   &--tone-neutral   .progress-bar__fill { background: var(--md-on-surface-variant); }
 
-  // -------- indeterminate --------
   &--indeterminate .progress-bar__fill {
     width: 35% !important;
     animation: blogsphere-progress-indeterminate 1.4s cubic-bezier(0.4, 0, 0.2, 1) infinite;
   }
 
-  // -------- striped --------
   &--striped .progress-bar__fill {
     background-image: linear-gradient(
       45deg,

--- a/src/app/shared/components/quick-action-tile/quick-action-tile.component.scss
+++ b/src/app/shared/components/quick-action-tile/quick-action-tile.component.scss
@@ -7,18 +7,14 @@
 }
 
 .quick-action-tile {
+  @include md-card($border-radius-md, $spacing-lg);
   position: relative;
   width: 100%;
   height: 100%;
   display: flex;
   align-items: center;
   gap: $spacing-md;
-  padding: $spacing-lg;
   text-align: left;
-  background: var(--md-surface-container-lowest);
-  border: 1px solid var(--md-outline-variant);
-  border-radius: $border-radius-md;
-  box-shadow: var(--md-elevation-card);
   font-family: $font-family-body;
   cursor: pointer;
   transition: box-shadow 200ms ease, transform 200ms ease, border-color 200ms ease,
@@ -36,15 +32,13 @@
   }
 
   &:focus-visible {
-    outline: 2px solid var(--md-primary);
-    outline-offset: 2px;
+    @include focus-ring;
   }
 
   &:disabled,
   &--disabled,
   &--loading {
-    cursor: not-allowed;
-    opacity: 0.6;
+    @include disabled-state;
     transform: none;
   }
 
@@ -96,7 +90,7 @@
     border-radius: 50%;
     border: 2px solid currentColor;
     border-top-color: transparent;
-    animation: blogsphere-quick-action-spin 600ms linear infinite;
+    animation: blogsphere-inline-spin 600ms linear infinite;
   }
 
   &__text {
@@ -127,8 +121,4 @@
     font-size: 1.25rem;
     transition: transform 200ms ease, color 200ms ease;
   }
-}
-
-@keyframes blogsphere-quick-action-spin {
-  to { transform: rotate(360deg); }
 }

--- a/src/app/shared/components/segmented-control/segmented-control.component.scss
+++ b/src/app/shared/components/segmented-control/segmented-control.component.scss
@@ -44,13 +44,11 @@
     }
 
     &:focus-visible {
-      outline: 2px solid var(--md-primary);
-      outline-offset: 2px;
+      @include focus-ring;
     }
 
     &:disabled {
-      opacity: 0.45;
-      cursor: not-allowed;
+      @include disabled-state;
     }
   }
 
@@ -59,7 +57,6 @@
     font-size: 1em;
   }
 
-  // -------- sizes --------
   &--size-sm .segmented-control__option {
     padding: 0.25rem $spacing-sm;
     font-size: $type-label-sm-size;
@@ -81,7 +78,6 @@
     min-height: 2.75rem;
   }
 
-  // -------- tones (selected state color) --------
   &--tone-neutral .segmented-control__option--active {
     background: var(--md-surface-container-lowest);
     color: var(--md-on-surface);

--- a/src/app/shared/components/stat-tile/stat-tile.component.html
+++ b/src/app/shared/components/stat-tile/stat-tile.component.html
@@ -7,10 +7,13 @@
     <span class="stat-tile__label">{{ label }}</span>
 
     <div *ngIf="delta || caption" class="stat-tile__meta">
-      <span *ngIf="delta" class="stat-tile__delta" [ngClass]="deltaToneClass">
-        <span class="material-symbols-rounded stat-tile__delta-icon" aria-hidden="true">{{ deltaIcon }}</span>
-        <span class="stat-tile__delta-value">{{ delta.value }}</span>
-      </span>
+      <blogsphere-status-pill
+        *ngIf="delta"
+        [tone]="deltaPillTone"
+        [icon]="deltaIcon"
+        [label]="delta.value"
+        size="sm"
+      ></blogsphere-status-pill>
       <span *ngIf="caption" class="stat-tile__caption">{{ caption }}</span>
     </div>
   </div>

--- a/src/app/shared/components/stat-tile/stat-tile.component.scss
+++ b/src/app/shared/components/stat-tile/stat-tile.component.scss
@@ -93,42 +93,8 @@
   }
 
   &__meta {
-    display: flex;
-    align-items: center;
-    gap: $spacing-sm;
-    flex-wrap: wrap;
+    @include cluster($spacing-sm);
     margin-top: $spacing-xs;
-  }
-
-  &__delta {
-    display: inline-flex;
-    align-items: center;
-    gap: $spacing-xs;
-    padding: 0.125rem $spacing-sm;
-    border-radius: $border-radius-full;
-    font-size: $type-label-sm-size;
-    font-weight: $font-weight-medium;
-    line-height: $type-label-sm-line;
-  }
-
-  &__delta-icon {
-    font-size: 1rem;
-    line-height: 1;
-  }
-
-  &__delta--positive {
-    background: rgba(16, 185, 129, 0.12);
-    color: #047857;
-  }
-
-  &__delta--negative {
-    background: rgba(186, 26, 26, 0.12);
-    color: var(--md-error);
-  }
-
-  &__delta--neutral {
-    background: var(--md-surface-container);
-    color: var(--md-on-surface-variant);
   }
 
   &__caption {

--- a/src/app/shared/components/stat-tile/stat-tile.component.ts
+++ b/src/app/shared/components/stat-tile/stat-tile.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input } from '@angular/core';
+import { StatusPillTone } from '../status-pill/status-pill.component';
 
 export type StatTileTone = 'primary' | 'info' | 'success' | 'warning' | 'danger';
 
@@ -18,12 +19,10 @@ export interface StatTileDelta {
   standalone: false,
 })
 export class StatTileComponent {
-  @Input() icon: string = '';
+  @Input() icon = '';
   @Input() value: string | number = '';
-  @Input() label: string = '';
+  @Input() label = '';
   @Input() tone: StatTileTone = 'primary';
-
-  // Phase-1 redesign additions — optional, backward-compatible.
   @Input() delta?: StatTileDelta;
   @Input() caption?: string;
 
@@ -38,7 +37,14 @@ export class StatTileComponent {
     }
   }
 
-  get deltaToneClass(): string {
-    return `stat-tile__delta--${this.delta?.tone ?? 'neutral'}`;
+  get deltaPillTone(): StatusPillTone {
+    switch (this.delta?.tone ?? 'neutral') {
+      case 'positive':
+        return 'success';
+      case 'negative':
+        return 'error';
+      default:
+        return 'neutral';
+    }
   }
 }

--- a/src/app/shared/components/stat-tile/stat-tile.module.ts
+++ b/src/app/shared/components/stat-tile/stat-tile.module.ts
@@ -1,10 +1,11 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { StatTileComponent } from './stat-tile.component';
+import { StatusPillModule } from '../status-pill/status-pill.module';
 
 @NgModule({
   declarations: [StatTileComponent],
-  imports: [CommonModule],
+  imports: [CommonModule, StatusPillModule],
   exports: [StatTileComponent],
 })
 export class StatTileModule {}

--- a/src/app/shared/components/status-pill/status-pill.component.html
+++ b/src/app/shared/components/status-pill/status-pill.component.html
@@ -1,4 +1,18 @@
-<span class="status-pill" [ngClass]="'status-pill--' + state">
-  <span class="material-symbols-rounded status-pill__icon" aria-hidden="true">{{ resolvedIcon }}</span>
+<span
+  class="status-pill"
+  [class.status-pill--success]="resolvedTone === 'success'"
+  [class.status-pill--warning]="resolvedTone === 'warning'"
+  [class.status-pill--error]="resolvedTone === 'error'"
+  [class.status-pill--info]="resolvedTone === 'info'"
+  [class.status-pill--neutral]="resolvedTone === 'neutral'"
+  [class.status-pill--sm]="size === 'sm'"
+  role="status"
+  [attr.aria-label]="label"
+>
+  <span
+    *ngIf="resolvedIcon"
+    class="material-symbols-rounded status-pill__icon"
+    aria-hidden="true"
+  >{{ resolvedIcon }}</span>
   <span class="status-pill__label">{{ label }}</span>
 </span>

--- a/src/app/shared/components/status-pill/status-pill.component.scss
+++ b/src/app/shared/components/status-pill/status-pill.component.scss
@@ -6,41 +6,28 @@
 }
 
 .status-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: $spacing-xs;
-  padding: 4px 10px;
-  border-radius: $border-radius-full;
-  @include font($font-size-base, $font-weight-medium);
-  white-space: nowrap;
+  @include status-pill('neutral');
 
   &__icon {
-    font-size: 18px;
+    font-size: 1rem;
     line-height: 1;
-    flex-shrink: 0;
   }
 
   &__label {
     line-height: 1;
   }
 
-  &--success {
-    background: rgba($color-success, 0.1);
-    color: $color-success-dark;
-  }
+  &--success { @include status-pill('success'); }
+  &--warning { @include status-pill('warning'); }
+  &--error   { @include status-pill('error'); }
+  &--info    { @include status-pill('info'); }
+  &--neutral { @include status-pill('neutral'); }
 
-  &--warning {
-    background: rgba($color-warning, 0.14);
-    color: $color-warning-dark;
-  }
+  &--sm {
+    padding: 1px $spacing-xs;
 
-  &--danger {
-    background: rgba($color-error, 0.08);
-    color: $color-error-dark;
-  }
-
-  &--neutral {
-    background: rgba($color-text-primary, 0.06);
-    color: rgba($color-text-primary, 0.7);
+    .status-pill__icon {
+      font-size: 0.875rem;
+    }
   }
 }

--- a/src/app/shared/components/status-pill/status-pill.component.ts
+++ b/src/app/shared/components/status-pill/status-pill.component.ts
@@ -1,4 +1,7 @@
-import { Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+
+export type StatusPillTone = 'success' | 'warning' | 'error' | 'info' | 'neutral';
+export type StatusPillSize = 'sm' | 'md';
 
 export type StatusPillState = 'success' | 'warning' | 'danger' | 'neutral';
 
@@ -9,18 +12,60 @@ const DEFAULT_ICON_FOR_STATE: Record<StatusPillState, string> = {
   neutral: 'help',
 };
 
+/**
+ * Compact pill used to surface a status / delta / badge value.
+ *
+ * Preferred inputs (new):
+ *  - `tone`   semantic color (success / warning / error / info / neutral)
+ *  - `icon`   optional Material symbol shown to the left of the label
+ *  - `label`  required text content (also used as accessible label)
+ *  - `size`   `sm` (24px h) or `md` (28px h, default)
+ *
+ * Legacy compatibility inputs (kept so older call sites keep working):
+ *  - `state`  `success` | `warning` | `danger` | `neutral` — maps to a tone.
+ *             When `state` is set and `icon` is `null`, a sensible default
+ *             icon is rendered (`check_circle`, `warning`, `cancel`, `help`).
+ */
 @Component({
   selector: 'blogsphere-status-pill',
   templateUrl: './status-pill.component.html',
   styleUrls: ['./status-pill.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: false,
 })
 export class StatusPillComponent {
-  @Input() state: StatusPillState = 'neutral';
-  @Input() label: string = '';
-  @Input() icon: string | null = null;
+  @Input() tone?: StatusPillTone;
+  @Input() icon?: string | null;
+  @Input() label = '';
+  @Input() size: StatusPillSize = 'md';
 
-  public get resolvedIcon(): string {
-    return this.icon ?? DEFAULT_ICON_FOR_STATE[this.state];
+  @Input() state?: StatusPillState;
+
+  get resolvedTone(): StatusPillTone {
+    if (this.tone) {
+      return this.tone;
+    }
+    switch (this.state) {
+      case 'success':
+        return 'success';
+      case 'warning':
+        return 'warning';
+      case 'danger':
+        return 'error';
+      case 'neutral':
+        return 'neutral';
+      default:
+        return 'neutral';
+    }
+  }
+
+  get resolvedIcon(): string | null {
+    if (this.icon !== undefined && this.icon !== null && this.icon !== '') {
+      return this.icon;
+    }
+    if (this.state) {
+      return DEFAULT_ICON_FOR_STATE[this.state];
+    }
+    return null;
   }
 }

--- a/src/assets/styles/_angular-material-theme.scss
+++ b/src/assets/styles/_angular-material-theme.scss
@@ -465,3 +465,42 @@ mat-slide-toggle,
 .mat-mdc-progress-spinner {
   --mdc-circular-progress-active-indicator-color: var(--mat-sys-primary);
 }
+
+// ============================================================================
+// XNG-BREADCRUMB — global hooks for the third-party breadcrumb library so
+// every page-header instance stays in the AGL palette without ::ng-deep.
+// ============================================================================
+
+.xng-breadcrumb-root {
+  display: flex;
+  align-items: center;
+  gap: $spacing-xs;
+  font-family: $font-family-body;
+  font-size: $type-label-sm-size;
+  line-height: $type-label-sm-line;
+}
+
+.xng-breadcrumb-item {
+  display: inline-flex;
+  align-items: center;
+}
+
+.xng-breadcrumb-link {
+  color: var(--mat-sys-on-surface-variant);
+  text-decoration: none;
+
+  &:hover {
+    color: var(--mat-sys-secondary);
+    text-decoration: underline;
+  }
+}
+
+.xng-breadcrumb-trail {
+  color: var(--mat-sys-on-surface);
+  font-weight: $font-weight-medium;
+}
+
+.xng-breadcrumb-separator {
+  color: var(--mat-sys-outline);
+  margin: 0 $spacing-xs;
+}

--- a/src/assets/styles/base/_prototype-utilities.scss
+++ b/src/assets/styles/base/_prototype-utilities.scss
@@ -258,6 +258,57 @@
 .group:hover .group-hover\:opacity-100 { opacity: 1; }
 
 // ============================================================================
+// LAYOUT PRIMITIVES — stack / cluster / row-between / page-container
+// ============================================================================
+
+.stack            { @include stack($spacing-md); }
+.stack-xs         { @include stack($spacing-xs); }
+.stack-sm         { @include stack($spacing-sm); }
+.stack-lg         { @include stack($spacing-lg); }
+.stack-xl         { @include stack($spacing-xl); }
+
+.cluster          { @include cluster($spacing-md); }
+.cluster-xs       { @include cluster($spacing-xs); }
+.cluster-sm       { @include cluster($spacing-sm); }
+.cluster-lg       { @include cluster($spacing-lg); }
+
+.row-between      { @include row-between($spacing-md); }
+
+.page-container   { @include page-container; }
+
+.section-stack    { @include section-stack; }
+
+.grid-auto-fit-sm { @include grid-auto-fit(14rem, $spacing-md); }
+.grid-auto-fit-md { @include grid-auto-fit(18rem, $spacing-md); }
+.grid-auto-fit-lg { @include grid-auto-fit(22rem, $spacing-md); }
+
+.grid-bento       { @include grid-bento; }
+.grid-bento-2x4   { @include grid-bento(1, 2, 4, $spacing-md); }
+
+// ============================================================================
+// INTERACTION + ACCESSIBILITY
+// ============================================================================
+
+.focus-ring:focus-visible { @include focus-ring; }
+.touch-target             { @include touch-target; }
+.hover-surface-bg         { @include hover-surface; }
+.is-disabled              { @include disabled-state; }
+
+// ============================================================================
+// STATUS COLORS
+// ============================================================================
+
+.bg-status-success-container { background-color: var(--md-status-success-container); }
+.bg-status-warning-container { background-color: var(--md-status-warning-container); }
+.bg-status-error-container   { background-color: var(--md-status-error-container); }
+.bg-status-info-container    { background-color: var(--md-status-info-container); }
+
+.text-status-success { color: var(--md-status-success); }
+.text-status-warning { color: var(--md-status-warning); }
+.text-status-error   { color: var(--md-status-error); }
+.text-status-info    { color: var(--md-status-info); }
+
+// ============================================================================
 // MISC
 // ============================================================================
 

--- a/src/assets/styles/sass-utils/_mixins.scss
+++ b/src/assets/styles/sass-utils/_mixins.scss
@@ -41,6 +41,243 @@
   }
 }
 
+@mixin mobile-only    { @include respond-to(xs) { @content; } }
+@mixin tablet-up      { @include respond-to(sm) { @content; } }
+@mixin desktop-up     { @include respond-to(md) { @content; } }
+@mixin wide-up        { @include respond-to(lg) { @content; } }
+@mixin mobile-tablet  { @include respond-between($breakpoint-xs, $breakpoint-md) { @content; } }
+
+@mixin stack($gap: $spacing-md) {
+  display: flex;
+  flex-direction: column;
+  gap: $gap;
+}
+
+@mixin cluster($gap: $spacing-md, $wrap: wrap, $align: center, $justify: flex-start) {
+  display: flex;
+  flex-wrap: $wrap;
+  gap: $gap;
+  align-items: $align;
+  justify-content: $justify;
+}
+
+@mixin row-between($gap: $spacing-md, $wrap: wrap, $align: center) {
+  display: flex;
+  flex-wrap: $wrap;
+  gap: $gap;
+  align-items: $align;
+  justify-content: space-between;
+}
+
+@mixin page-container {
+  width: 100%;
+  max-width: $container-max;
+  margin-inline: auto;
+  padding-inline: $page-margin-mobile;
+
+  @include desktop-up {
+    padding-inline: $page-margin-desktop;
+  }
+}
+
+@mixin section-stack($gap-mobile: $spacing-lg, $gap-desktop: $spacing-xl) {
+  display: flex;
+  flex-direction: column;
+  gap: $gap-mobile;
+
+  @include desktop-up {
+    gap: $gap-desktop;
+  }
+}
+
+@mixin grid-auto-fit($min: 16rem, $gap: $spacing-md) {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax($min, 1fr));
+  gap: $gap;
+}
+
+@mixin grid-bento(
+  $cols-mobile: 1,
+  $cols-tablet: 2,
+  $cols-desktop: 3,
+  $gap: $spacing-md
+) {
+  display: grid;
+  grid-template-columns: repeat($cols-mobile, minmax(0, 1fr));
+  gap: $gap;
+
+  @include tablet-up {
+    grid-template-columns: repeat($cols-tablet, minmax(0, 1fr));
+  }
+  @include desktop-up {
+    grid-template-columns: repeat($cols-desktop, minmax(0, 1fr));
+  }
+}
+
+@mixin offcanvas-drawer(
+  $side: left,
+  $width: $sidebar-width,
+  $duration: 0.25s,
+  $z: $z-index-modal
+) {
+  position: fixed;
+  top: 0;
+  width: $width;
+  height: 100%;
+  z-index: $z;
+  transition: transform $duration ease-in-out;
+
+  @if $side == left {
+    left: 0;
+    transform: translateX(-100%);
+  } @else {
+    right: 0;
+    transform: translateX(100%);
+  }
+
+  &.is-open {
+    transform: translateX(0);
+  }
+}
+
+@mixin overlay-backdrop($z: $z-index-modal-backdrop) {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: $z;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s ease-in-out, visibility 0.3s ease-in-out;
+
+  &.is-open {
+    opacity: 1;
+    visibility: visible;
+  }
+}
+
+@mixin focus-ring($color: var(--md-primary), $offset: 2px, $width: 2px) {
+  outline: $width solid $color;
+  outline-offset: $offset;
+}
+
+@mixin touch-target($min: 2.75rem) {
+  min-width: $min;
+  min-height: $min;
+}
+
+@mixin reduced-motion-safe {
+  @media (prefers-reduced-motion: no-preference) {
+    @content;
+  }
+}
+
+@mixin hover-surface($bg: var(--md-surface-container)) {
+  transition: background-color 200ms ease;
+
+  &:hover {
+    background-color: $bg;
+  }
+}
+
+@mixin disabled-state {
+  opacity: 0.5;
+  pointer-events: none;
+  cursor: not-allowed;
+}
+
+@mixin md-card($radius: $border-radius-md, $padding: $spacing-lg) {
+  background: var(--md-surface-container-lowest);
+  border: 1px solid var(--md-outline-variant);
+  border-radius: $radius;
+  box-shadow: var(--md-elevation-card);
+  padding: $padding;
+}
+
+@mixin md-card-hover($lift: 2px) {
+  transition: transform 200ms ease, box-shadow 200ms ease;
+
+  &:hover {
+    transform: translateY(-#{$lift});
+    box-shadow: var(--md-elevation-card-hover);
+  }
+}
+
+@mixin status-pill($tone: 'success') {
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-xs;
+  padding: 2px $spacing-sm;
+  border-radius: $border-radius-full;
+  font-family: $font-family-body;
+  font-size: $type-label-xs-size;
+  line-height: $type-label-xs-line;
+  font-weight: $type-label-xs-weight;
+  letter-spacing: $type-label-xs-tracking;
+  text-transform: uppercase;
+  white-space: nowrap;
+
+  @if $tone == success {
+    background: var(--md-status-success-container);
+    color: var(--md-status-success);
+  } @else if $tone == warning {
+    background: var(--md-status-warning-container);
+    color: var(--md-status-warning);
+  } @else if $tone == error {
+    background: var(--md-status-error-container);
+    color: var(--md-status-error);
+  } @else if $tone == info {
+    background: var(--md-status-info-container);
+    color: var(--md-status-info);
+  } @else {
+    background: var(--md-surface-container-high);
+    color: var(--md-on-surface-variant);
+  }
+}
+
+@mixin eyebrow-label($color: var(--md-on-surface-variant)) {
+  font-family: $font-family-body;
+  font-size: $type-label-xs-size;
+  line-height: $type-label-xs-line;
+  font-weight: $type-label-xs-weight;
+  letter-spacing: $type-label-xs-tracking;
+  text-transform: uppercase;
+  color: $color;
+}
+
+@mixin material-icon($size: 1.5rem) {
+  font-family: 'Material Symbols Rounded', 'Material Symbols Outlined', sans-serif;
+  font-weight: normal;
+  font-style: normal;
+  font-size: $size;
+  line-height: 1;
+  letter-spacing: normal;
+  text-transform: none;
+  display: inline-block;
+  white-space: nowrap;
+  word-wrap: normal;
+  direction: ltr;
+  font-feature-settings: 'liga';
+  -webkit-font-feature-settings: 'liga';
+  -webkit-font-smoothing: antialiased;
+  font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+}
+
+@mixin inline-spinner($size: 1.25rem, $color: currentColor) {
+  width: $size;
+  height: $size;
+  border: 2px solid rgba(0, 0, 0, 0.08);
+  border-top-color: $color;
+  border-radius: 50%;
+  animation: blogsphere-inline-spin 0.75s linear infinite;
+}
+
+@mixin collapse-rows($duration: 0.25s, $timing: ease-in-out) {
+  display: grid;
+  grid-template-rows: 0fr;
+  overflow: hidden;
+  transition: grid-template-rows $duration $timing;
+}
+
 // ============================================================================
 // FLEXBOX MIXINS
 // ============================================================================

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -87,6 +87,18 @@
   --md-error-container: #{$md-error-container};
   --md-on-error-container: #{$md-on-error-container};
 
+  // Status (semantic surfaces for charts, pills, badges)
+  --md-status-success: #{$success-700};
+  --md-status-success-container: #{$success-100};
+  --md-status-warning: #{$warning-800};
+  --md-status-warning-container: #{$warning-100};
+  --md-status-error: #{$md-error};
+  --md-status-error-container: #{$md-error-container};
+  --md-status-info: #{$info-700};
+  --md-status-info-container: #{$info-100};
+  --md-status-neutral: #{$md-on-surface-variant};
+  --md-status-neutral-container: #{$md-surface-container-high};
+
   // Elevation
   --md-elevation-card: #{$md-elevation-card};
   --md-elevation-card-hover: #{$md-elevation-card-hover};
@@ -222,14 +234,19 @@
 }
 
 // ============================================================================
-// GLOBAL BEHAVIOR SETTINGS
+// GLOBAL KEYFRAMES
 // ============================================================================
 
-// Disable text selection globally
-// * {
-//   -webkit-user-select: none; /* Safari */
-//   -moz-user-select: none; /* Firefox */
-//   -ms-user-select: none; /* IE10+/Edge */
-//   user-select: none; /* Standard */
-//   -webkit-touch-callout: none; /* iOS Safari */
-// }
+@keyframes blogsphere-inline-spin {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes blogsphere-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@keyframes blogsphere-slide-up {
+  from { opacity: 0; transform: translateY(0.5rem); }
+  to   { opacity: 1; transform: translateY(0); }
+}


### PR DESCRIPTION
## Summary

This sub-PR targets the umbrella `feat/ui-redesign-foundation` branch and delivers the Phase 1.5 + Phase 2 work without touching `main`. After verification it will be merged into the umbrella branch alongside Phase 3 and Phase 4 before PR #8 is refreshed.

### 1. Shell bug fixes

1. **Desktop collapse** — `SidebarComponent` now sets a `host--collapsed` `HostBinding`. `SidebarNavLink` + `SidebarExpandableNavItem` take a `[collapsed]` input, hide labels / chevrons via `:host(.host--collapsed)`, and surface destinations through `MatTooltip` while the rail is collapsed. The rail expands on hover so the existing toggle button still feels familiar.
2. **Shell scroll** — `.app-shell` is now `height: 100vh; overflow: hidden;` with `.app-shell__main` as the only scroll container. Navbar and sidebar dropped `position: sticky`. Navbar exposes `:host { display:block; flex-shrink:0; }`.
3. **Mobile host width / state machine** — `:host` collapses to `width:0` at `mobile-only`. The `selectMobileViewState` subscription now sets `isMobileView` unconditionally and only dispatches `ToggleSideNav` on the desktop→mobile transition while the rail was open.
4. **Drawer / backdrop z-index** — mobile `.sidenav` lifts to `$z-index-modal` (1050) so it paints above the `$z-index-modal-backdrop` (1040) sheet. Backdrop click dispatches `ToggleSideNav`.
5. **Submenu animation** — `.sidebar-expandable__submenu` uses the new `collapse-rows` mixin (`0fr → 1fr`) and the `@for` block is wrapped in `.sidebar-expandable__submenu-inner` with `overflow:hidden`, `flex column`, `gap`, and an opacity tied to the `--open` modifier. `aria-hidden` is bound to `!expanded || collapsed`. Submenu rows no longer overlap during the transition.

All five fixes verified via Chrome DevTools at 1440 / 768 / 375; screenshots under `.cursor/redesign/after/phase1.5/`.

### 2. Responsive SCSS library

New mixins in `sass-utils/_mixins.scss`:

- Breakpoint sugar: `mobile-only`, `tablet-up`, `desktop-up`, `wide-up`, `mobile-tablet`.
- Layout primitives: `stack`, `cluster`, `row-between`, `page-container`, `section-stack`, `grid-auto-fit`, `grid-bento`.
- Mobile drawer: `offcanvas-drawer`, `overlay-backdrop`.
- Interaction / a11y: `focus-ring`, `touch-target`, `reduced-motion-safe`, `hover-surface`, `disabled-state`.
- Pattern lifts (used by Phase 1 components): `md-card`, `md-card-hover`, `status-pill`, `eyebrow-label`, `material-icon`, `inline-spinner`, `collapse-rows`.

Matching utility classes added to `base/_prototype-utilities.scss`: `.stack(-xs|-sm|-lg|-xl)`, `.cluster(-xs|-sm|-lg)`, `.row-between`, `.page-container`, `.section-stack`, `.grid-auto-fit-*`, `.grid-bento(-2x4)`, `.focus-ring`, `.touch-target`, `.hover-surface-bg`, `.is-disabled`, `.bg-status-*-container`, `.text-status-*`.

### 3. Design tokens + global keyframes

New `--md-status-(success|warning|error|info|neutral)` CSS variables (plus matching `-container` surfaces) on `:root`. `chart-theme.ts` now reads `--md-status-success` / `--md-status-warning` from those tokens instead of hardcoded hex.

Global keyframes `blogsphere-inline-spin`, `blogsphere-fade-in`, `blogsphere-slide-up` moved to `styles.scss` so component spinners can share them.

### 4. Global Material override sweep

`xng-breadcrumb` hooks lifted out of `page-header.component.scss` and into the global Material override block in `_angular-material-theme.scss`. Every `blogsphere-page-header` instance now picks up the AGL palette without `::ng-deep`.

### 5. New shared atoms

- **`blogsphere-chart-card`** (new): `eyebrow / title / subtitle / [toolbar] / body / [loading]` slots, `bodyHeight` / `bodyMaxWidth`, OnPush. Replaces the chart-shell pattern that was duplicated across both pilot dashboards.
- **`blogsphere-status-pill`** (hardened — backward-compatible upgrade): adds the M3-aligned `tone` (success / warning / error / info / neutral) + `size` (sm / md) inputs alongside the existing `state` (success / warning / danger / neutral) API used in `user-manager`, `api-routes`, and `management-user-details`. Both APIs resolve through `resolvedTone` / `resolvedIcon`, so the legacy templates keep working unchanged.

### 6. Phase 1 component refactor

- `metric-card` + `stat-tile`: delta surfaces now use `<blogsphere-status-pill>` (positive → success / negative → error / neutral → neutral). ~30 lines of duplicated delta SCSS removed. `metric-card` consumes `md-card`, `md-card-hover`, `eyebrow-label`. Success accent reads from `--md-status-success`.
- `icon-button`, `segmented-control`, `quick-action-tile`: consume `focus-ring` + `disabled-state` (+ `md-card` for tile). `quick-action-tile` and `icon-button` now share the global `blogsphere-inline-spin` keyframe.
- `progress-bar`: success / warning tones read from `--md-status-*` tokens.
- `page-header`: drops the breadcrumb `::ng-deep` block and flips `__title-text` to mobile-first (`headline-lg-mobile` default, `headline-lg` from `desktop-up`).

### 7. Dashboard migration onto chart-card

Both `api-management-dashboard` and `user-management-dashboard` charts are wrapped in `<blogsphere-chart-card>`. ~150 lines of duplicated chart-shell SCSS deleted; the per-dashboard `.chart-body--line / --bar / --doughnut` height rules collapse to a single `bodyHeight` input. Loading states use the chart-card's built-in spinner instead of bespoke `<mat-progress-spinner>` blocks. Bento grids in both pages now consume `section-stack`, `tablet-up`, `desktop-up`, `wide-up`.

## Test plan

- [ ] Visual regression at 1440 / 768 / 375 on `/dashboard` (both scopes), `/api-cluster`, `/api-route`, `/subscription`, `/user-manager/app-users`, `/user-manager/management-users`, `/user-profile`. Screenshots are under `.cursor/redesign/after/phase1.5/`.
- [ ] Desktop collapse rail expands on hover and tooltips fire on collapsed icons.
- [ ] Page scrolling: only `.app-shell__main` scrolls; topbar + sidenav stay pinned.
- [ ] Mobile drawer opens above the backdrop (z-index 1050 vs 1040) and the backdrop click closes it.
- [ ] Sidebar submenu animation (Api manager / User manager) collapses cleanly without overlap.
- [ ] Metric-card + stat-tile delta pills render with the new status tones.
- [ ] Dashboard charts: line / bar / doughnut all paint under the new chart-card surface, including loading state.
- [ ] `route-details` and `management-user-details` still render the legacy `[state]` status-pills correctly.
- [ ] `ng build --configuration=production` succeeds (it does; pre-existing budget warnings on `route-details.component.scss` and `user-profile.component.scss` will be split in PR 3 and PR 4).

## Follow-up

Merge order:

1. Verify this sub-PR.
2. Merge into `feat/ui-redesign-foundation` via `merge_pull_request` MCP.
3. Prune the sub-branch; then branch PR 3 (`feat/ui-redesign-phase3-heavy-features`) off the freshly updated `feat/ui-redesign-foundation`.