### PR TITLE
Phase 3 — heavy data features: table, paginator, badge, api-routes, api-cluster, subscription

### DIFF
--- a/src/app/features/api-cluster/cluster-details/cluster-details.component.scss
+++ b/src/app/features/api-cluster/cluster-details/cluster-details.component.scss
@@ -26,7 +26,7 @@
   @include md-card($padding: $spacing-lg $spacing-xl);
   @include flex-column;
   gap: $spacing-xs;
-  border-left: 3px solid var(--mat-sys-primary);
+  border-left: 3px solid var(--mat-sys-secondary);
   transition: box-shadow 200ms ease, transform 200ms ease;
 
   &:hover {

--- a/src/app/features/api-cluster/cluster-details/cluster-details.component.scss
+++ b/src/app/features/api-cluster/cluster-details/cluster-details.component.scss
@@ -2,74 +2,66 @@
 @use 'sass-utils/mixins' as *;
 
 .cd {
-  max-width: 1280px;
+  max-width: $container-max;
   margin: 0 auto;
   padding: $spacing-xl $spacing-xl $spacing-3xl;
-  display: flex;
-  flex-direction: column;
+  @include flex-column;
   gap: $spacing-xl;
 
-  @include respond-to(xs) {
+  @include mobile-only {
     padding: $spacing-md $spacing-md $spacing-2xl;
     gap: $spacing-lg;
   }
 }
 
 .cd-stats {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: $spacing-md;
+  @include grid-auto-fit(12.5rem, $spacing-md);
 
-  @include respond-to(xs) {
+  @include mobile-only {
     grid-template-columns: 1fr 1fr;
   }
 }
 
 .cd-stat {
-  @include card;
-  padding: $spacing-lg $spacing-xl;
-  display: flex;
-  flex-direction: column;
+  @include md-card($padding: $spacing-lg $spacing-xl);
+  @include flex-column;
   gap: $spacing-xs;
-  border-left: 3px solid $color-primary;
-  @include transition(all);
+  border-left: 3px solid var(--mat-sys-primary);
+  transition: box-shadow 200ms ease, transform 200ms ease;
 
   &:hover {
-    box-shadow: 0 4px 12px $color-shadow;
+    box-shadow: var(--md-elevation-card-hover);
     transform: translateY(-1px);
   }
 
   &__label {
-    @include font($font-size-base, $font-weight-medium);
-    color: rgba($color-text-primary, 0.55);
-    text-transform: uppercase;
-    letter-spacing: 0.8px;
+    @include eyebrow-label(var(--mat-sys-on-surface-variant));
   }
 
   &__value {
-    @include font($font-size-xl, $font-weight-medium);
-    color: $color-text-primary;
+    font-size: $type-headline-sm-size;
+    line-height: $type-headline-sm-line;
+    font-weight: $font-weight-medium;
+    color: var(--mat-sys-on-surface);
     word-break: break-word;
   }
 }
 
 .cd-empty {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
+  @include flex-column-center;
   gap: $spacing-sm;
   padding: $spacing-xl $spacing-lg;
   text-align: center;
 
   &__icon {
-    font-size: 36px;
-    color: rgba($color-text-primary, 0.15);
+    font-size: 2.25rem;
+    color: var(--mat-sys-outline-variant);
   }
 
   &__text {
-    @include font($font-size-lg, $font-weight-regular);
-    color: rgba($color-text-primary, 0.45);
+    font-size: $type-body-lg-size;
+    line-height: $type-body-lg-line;
+    color: var(--mat-sys-on-surface-variant);
     margin: 0;
     max-width: 40ch;
   }

--- a/src/app/features/api-cluster/cluster-setup/cluster-setup.component.scss
+++ b/src/app/features/api-cluster/cluster-setup/cluster-setup.component.scss
@@ -3,86 +3,23 @@
 
 .cluster-form {
   &__header {
-    display: flex;
-    align-items: center;
-    gap: $spacing-sm;
+    @include cluster($spacing-sm);
   }
+
   &__footer {
     margin-top: $spacing-lg;
   }
+
   &__destinations {
     margin-top: $spacing-sm;
-    @include respond-to(xs) {
-      overflow-x: scroll;
+
+    @include mobile-only {
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
     }
+
     .destinations__table {
-      width: 100%;
-      border-collapse: collapse;
-      @include card;
-      thead {
-        tr {
-          background-color: $gray-50;
-          // color: $color-text-inverse;
-          th {
-            padding: $spacing-md;
-            border: none;
-            position: relative;
-            font-weight: $font-weight-medium;
-            &::after {
-              content: '';
-              position: absolute;
-              right: 0;
-              top: 50%;
-              transform: translateY(-50%);
-              width: 1px;
-              height: 60%;
-              background-color: rgba(0, 0, 0, 0.2);
-            }
-
-            &:last-child::after {
-              display: none;
-            }
-          }
-        }
-      }
-
-      tbody {
-        tr {
-          &.bg-error {
-            background-color: rgba($color-error, 0.053);
-          }
-          td {
-            border: 1px solid $color-border;
-            padding: $spacing-md;
-            text-align: center;
-            border: none;
-            position: relative;
-            &::after {
-              content: '';
-              position: absolute;
-              right: 0;
-              top: 50%;
-              transform: translateY(-50%);
-              width: 1px;
-              height: 60%;
-              background-color: $color-border;
-            }
-
-            &:last-child::after {
-              display: none;
-            }
-            .form-field {
-              input {
-                border: none;
-                border-bottom: 1px solid $color-border;
-                outline: none;
-                background-color: transparent;
-                @include font($font-size-xl, $font-weight-regular, $line-height-normal);
-              }
-            }
-          }
-        }
-      }
+      @include form-table;
     }
   }
 }

--- a/src/app/features/api-routes/route-details/route-details.component.html
+++ b/src/app/features/api-routes/route-details/route-details.component.html
@@ -18,18 +18,7 @@
           </p>
           <div class="rd-hero-body__methods">
             @for (method of r.methods || []; track method) {
-              <span
-                class="method-pill"
-                [class.method-pill--get]="method === 'GET'"
-                [class.method-pill--post]="method === 'POST'"
-                [class.method-pill--put]="method === 'PUT'"
-                [class.method-pill--delete]="method === 'DELETE'"
-                [class.method-pill--patch]="method === 'PATCH'"
-                [class.method-pill--head]="method === 'HEAD'"
-                [class.method-pill--options]="method === 'OPTIONS'"
-              >
-                {{ method }}
-              </span>
+              <blogsphere-method-pill [method]="method"></blogsphere-method-pill>
             }
           </div>
         </div>
@@ -182,8 +171,8 @@
             @if ((r.headers || []).length) {
               <div class="rd-header-list">
                 @for (h of r.headers; track h.id) {
-                  <article class="rd-header-card">
-                    <span class="rd-header-card__icon">
+                  <article class="rd-row-card rd-header-card">
+                    <span class="rd-row-card__icon">
                       <span class="material-symbols-rounded">label</span>
                     </span>
                     <div class="rd-header-card__info">
@@ -200,7 +189,7 @@
                       }
                     </div>
                     <blogsphere-status-pill
-                      class="rd-header-card__status"
+                      class="rd-row-card__status"
                       [state]="h.isActive ? 'success' : 'danger'"
                       [label]="h.isActive ? 'Active' : 'Inactive'"
                     ></blogsphere-status-pill>
@@ -224,13 +213,13 @@
             @if ((r.transforms || []).length) {
               <div class="rd-transform-list">
                 @for (t of r.transforms; track t.id) {
-                  <article class="rd-transform-card">
-                    <span class="rd-transform-card__icon">
+                  <article class="rd-row-card rd-transform-card">
+                    <span class="rd-row-card__icon">
                       <span class="material-symbols-rounded">swap_horiz</span>
                     </span>
                     <code class="rd-transform-card__pattern" [matTooltip]="t.pathPattern">{{ t.pathPattern }}</code>
                     <blogsphere-status-pill
-                      class="rd-transform-card__status"
+                      class="rd-row-card__status"
                       [state]="t.isActive ? 'success' : 'danger'"
                       [label]="t.isActive ? 'Active' : 'Inactive'"
                     ></blogsphere-status-pill>

--- a/src/app/features/api-routes/route-details/route-details.component.scss
+++ b/src/app/features/api-routes/route-details/route-details.component.scss
@@ -1,58 +1,45 @@
 @use 'sass-utils/variables' as *;
 @use 'sass-utils/mixins' as *;
 
-// ============================================================================
-// PAGE SHELL
-// ============================================================================
 .rd {
-  max-width: 1280px;
+  max-width: $container-max;
   margin: 0 auto;
   padding: $spacing-lg $spacing-xl $spacing-2xl;
   @include flex-column;
   gap: $spacing-lg;
 
-  @include respond-to(xs) {
+  @include mobile-only {
     padding: $spacing-md $spacing-md $spacing-2xl;
-    gap: $spacing-lg;
   }
 }
 
-.rd-grid-row {
-  margin-bottom: 0;
-}
+.rd-grid-row { margin-bottom: 0; }
 
-// ============================================================================
-// HERO BODY (slotted into blogsphere-page-hero) — route-specific identity
-// content: path code chip + HTTP method pills.
-// ============================================================================
 .rd-hero-body {
   &__path {
-    display: inline-flex;
-    align-items: center;
-    gap: $spacing-xs;
+    @include cluster($spacing-xs);
     max-width: 100%;
     margin: 0 0 $spacing-md;
-    @include font($font-size-base, $font-weight-regular);
-    color: rgba($color-text-primary, 0.7);
+    font-size: $type-body-md-size;
+    color: var(--mat-sys-on-surface-variant);
 
-    @include respond-to(xs) {
-      justify-content: center;
-    }
+    @include mobile-only { justify-content: center; }
   }
 
   &__path-icon {
-    font-size: 18px;
+    font-size: 1.125rem;
     line-height: 1;
-    color: $color-primary;
+    color: var(--mat-sys-primary);
     flex-shrink: 0;
   }
 
   &__path-code {
-    font-family: $font-family-secondary;
-    @include font($font-size-xl, $font-weight-medium);
-    color: $color-primary;
-    background: rgba($color-primary, 0.06);
-    border: 1px solid rgba($color-primary, 0.12);
+    font-family: $font-family-mono;
+    font-size: $type-body-lg-size;
+    font-weight: $font-weight-medium;
+    color: var(--mat-sys-primary);
+    background: var(--mat-sys-primary-fixed);
+    border: 1px solid var(--mat-sys-outline-variant);
     border-radius: $border-radius-md;
     padding: 4px $spacing-sm;
     @include text-truncate;
@@ -60,171 +47,142 @@
   }
 
   &__methods {
-    display: flex;
-    flex-wrap: wrap;
-    gap: $spacing-xs;
-
-    @include respond-to(xs) {
-      justify-content: center;
-    }
+    @include cluster($spacing-xs);
+    @include mobile-only { justify-content: center; }
   }
 }
 
-.rd-hero-actions {
-  display: flex;
-  align-items: center;
-  gap: $spacing-sm;
-}
+.rd-hero-actions { @include cluster($spacing-sm); }
 
 .rd-hero-btn-icon {
-  font-size: 18px;
+  font-size: 1.125rem;
   line-height: 1;
 }
 
 .rd-hero-contact-item {
-  display: inline-flex;
-  align-items: center;
-  gap: $spacing-xs;
-  @include font($font-size-sm, $font-weight-regular);
-  color: rgba($color-text-primary, 0.7);
+  @include cluster($spacing-xs);
+  font-size: $type-body-sm-size;
+  color: var(--mat-sys-on-surface-variant);
   min-width: 0;
 
   &__icon {
-    font-size: 18px;
+    font-size: 1.125rem;
     line-height: 1;
-    color: $color-primary;
+    color: var(--mat-sys-primary);
     flex-shrink: 0;
   }
 
   &__text {
     @include text-truncate;
-    max-width: 260px;
-    @include transition(color);
+    max-width: 16.25rem;
+    transition: color 200ms ease;
 
     &--mono {
-      font-family: $font-family-secondary;
-      font-size: $font-size-sm;
-      color: rgba($color-text-primary, 0.6);
+      font-family: $font-family-mono;
       letter-spacing: 0.2px;
     }
   }
 
   &__link {
     @include text-truncate;
-    max-width: 260px;
-    color: $color-primary;
+    max-width: 16.25rem;
+    color: var(--mat-sys-primary);
     text-decoration: none;
-    @include font($font-size-sm, $font-weight-medium);
-    @include transition(color);
+    font-weight: $font-weight-medium;
+    font-size: $type-body-sm-size;
+    transition: color 200ms ease;
 
     &:hover {
-      color: $color-primary-dark;
+      color: var(--md-on-primary-fixed);
       text-decoration: underline;
     }
   }
-
-  &:hover &__text,
-  &:hover &__link {
-    color: $color-primary;
-  }
 }
 
-:host ::ng-deep .rd-card-grid {
-  blogsphere-details-card {
-    display: block;
-    height: 100%;
-
-    .details-card {
-      height: 100%;
-      display: flex;
-      flex-direction: column;
-    }
-
-    .details-card__body {
-      flex: 1;
-    }
-  }
+// Equal-height stretch helpers (pierce encapsulation only because the inner
+// templates live in shared modules)
+:host ::ng-deep .rd-card-grid blogsphere-details-card,
+:host ::ng-deep .rd-panel-grid blogsphere-section-panel {
+  display: block;
+  height: 100%;
 }
 
-:host ::ng-deep .rd-panel-grid {
-  blogsphere-section-panel {
-    display: block;
-    height: 100%;
-
-    .section-panel {
-      height: 100%;
-      display: flex;
-      flex-direction: column;
-    }
-
-    .section-panel__body {
-      flex: 1;
-    }
-  }
+:host ::ng-deep .rd-card-grid .details-card,
+:host ::ng-deep .rd-panel-grid .section-panel {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
-// ============================================================================
-// HEADER ROWS (route-specific compact rows inside the Headers section panel)
-// ============================================================================
-.rd-header-list {
-  @include flex-column;
-  gap: $spacing-sm;
+:host ::ng-deep .rd-card-grid .details-card__body,
+:host ::ng-deep .rd-panel-grid .section-panel__body {
+  flex: 1;
 }
 
-.rd-header-card {
+.rd-row-card {
   display: grid;
   grid-template-columns: auto 1fr auto;
   align-items: center;
   gap: $spacing-md;
   padding: $spacing-md $spacing-lg;
-  border: 1px solid $color-border-light;
+  border: 1px solid var(--mat-sys-outline-variant);
   border-radius: $border-radius-lg;
-  background: $color-background;
-  @include transition(all);
+  background: var(--mat-sys-surface-container-lowest);
+  transition: border-color 200ms ease, box-shadow 200ms ease, transform 200ms ease;
 
-  @include respond-to(xs) {
+  @include mobile-only {
     grid-template-columns: auto 1fr;
     gap: $spacing-sm $spacing-md;
   }
 
   &:hover {
-    border-color: rgba($color-primary, 0.3);
-    box-shadow: 0 4px 12px $color-shadow-light;
+    border-color: var(--mat-sys-primary);
+    box-shadow: var(--md-elevation-card);
     transform: translateY(-1px);
   }
 
   &__icon {
-    width: 36px;
-    height: 36px;
-    border-radius: $border-radius-md;
-    background: rgba($color-primary, 0.08);
     @include flex-center;
+    width: 2.25rem;
+    height: 2.25rem;
+    border-radius: $border-radius-md;
+    background: var(--mat-sys-primary-fixed);
     flex-shrink: 0;
     align-self: flex-start;
 
     .material-symbols-rounded {
-      font-size: 20px;
+      font-size: 1.25rem;
       line-height: 1;
-      color: $color-primary;
+      color: var(--mat-sys-primary);
     }
   }
 
+  @include mobile-only {
+    &__status {
+      grid-column: 1 / -1;
+      justify-self: start;
+    }
+  }
+}
+
+.rd-header-list,
+.rd-transform-list {
+  @include stack($spacing-sm);
+}
+
+.rd-header-card {
   &__info {
     @include flex-column;
     gap: $spacing-xs;
     min-width: 0;
   }
 
-  &__head {
-    display: flex;
-    align-items: center;
-    gap: $spacing-sm;
-    flex-wrap: wrap;
-  }
+  &__head { @include cluster($spacing-sm); }
 
   &__name {
-    @include font($font-size-lg, $font-weight-medium);
-    color: $color-text-primary;
+    font-size: $type-body-lg-size;
+    font-weight: $font-weight-medium;
+    color: var(--mat-sys-on-surface);
     word-break: break-word;
     line-height: 1.3;
   }
@@ -234,19 +192,16 @@
     align-items: center;
     padding: 2px $spacing-sm;
     border-radius: $border-radius-base;
-    background: rgba($color-info-dark, 0.1);
-    color: $color-info-dark;
-    @include font($font-size-xs, $font-weight-bold);
+    background: var(--md-status-info-container);
+    color: var(--md-status-info);
+    font-size: $type-label-xs-size;
+    font-weight: $type-label-xs-weight;
+    letter-spacing: $type-label-xs-tracking;
     text-transform: uppercase;
-    letter-spacing: 0.4px;
     line-height: 1.4;
   }
 
-  &__values {
-    display: flex;
-    flex-wrap: wrap;
-    gap: $spacing-xs;
-  }
+  &__values { @include cluster($spacing-xs); }
 
   &__value {
     display: inline-flex;
@@ -254,163 +209,56 @@
     max-width: 100%;
     padding: 3px $spacing-sm;
     border-radius: $border-radius-base;
-    background: $color-background-secondary;
-    border: 1px solid $color-border-light;
-    font-family: $font-family-secondary;
-    @include font($font-size-sm, $font-weight-regular);
-    color: rgba($color-text-primary, 0.85);
+    background: var(--mat-sys-surface-container);
+    border: 1px solid var(--mat-sys-outline-variant);
+    font-family: $font-family-mono;
+    font-size: $type-body-sm-size;
+    color: var(--mat-sys-on-surface);
     word-break: break-all;
   }
-
-  // On mobile, the status pill wraps to a new full-width row.
-  @include respond-to(xs) {
-    &__status {
-      grid-column: 1 / -1;
-      justify-self: start;
-    }
-  }
-}
-
-// ============================================================================
-// TRANSFORM ROWS
-// ============================================================================
-.rd-transform-list {
-  @include flex-column;
-  gap: $spacing-sm;
 }
 
 .rd-transform-card {
-  display: grid;
-  grid-template-columns: auto 1fr auto;
-  align-items: center;
-  gap: $spacing-md;
-  padding: $spacing-md $spacing-lg;
-  border: 1px solid $color-border-light;
-  border-radius: $border-radius-lg;
-  background: $color-background;
-  @include transition(all);
-
-  @include respond-to(xs) {
-    grid-template-columns: auto 1fr;
-    gap: $spacing-sm $spacing-md;
-  }
-
-  &:hover {
-    border-color: rgba($color-primary, 0.3);
-    box-shadow: 0 4px 12px $color-shadow-light;
-    transform: translateY(-1px);
-  }
-
-  &__icon {
-    width: 36px;
-    height: 36px;
-    border-radius: $border-radius-md;
-    background: rgba($color-primary, 0.08);
-    @include flex-center;
-    flex-shrink: 0;
-
-    .material-symbols-rounded {
-      font-size: 20px;
-      line-height: 1;
-      color: $color-primary;
-    }
-  }
-
   &__pattern {
-    font-family: $font-family-secondary;
-    @include font($font-size-base, $font-weight-medium);
-    color: $color-text-primary;
-    background: $color-background-secondary;
-    border: 1px solid $color-border-light;
+    font-family: $font-family-mono;
+    font-size: $type-body-md-size;
+    font-weight: $font-weight-medium;
+    color: var(--mat-sys-on-surface);
+    background: var(--mat-sys-surface-container);
+    border: 1px solid var(--mat-sys-outline-variant);
     border-radius: $border-radius-md;
     padding: 5px $spacing-sm;
     word-break: break-all;
     min-width: 0;
   }
-
-  // On mobile, the status pill wraps to a new full-width row.
-  @include respond-to(xs) {
-    &__status {
-      grid-column: 1 / -1;
-      justify-self: start;
-    }
-  }
 }
 
-// ============================================================================
-// AUTHOR (Audit creators)
-// ============================================================================
 .rd-author {
-  display: inline-flex;
-  align-items: center;
-  gap: $spacing-sm;
+  @include cluster($spacing-sm);
   cursor: pointer;
 
   &__avatar {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 28px;
-    height: 28px;
+    @include flex-center;
+    width: 1.75rem;
+    height: 1.75rem;
     border-radius: $border-radius-full;
-    background: $color-primary;
-    color: $color-text-inverse;
-    @include font($font-size-xs, $font-weight-bold);
+    background: var(--mat-sys-primary);
+    color: var(--mat-sys-on-primary);
+    font-size: $type-label-xs-size;
+    font-weight: $font-weight-bold;
     text-transform: uppercase;
     flex-shrink: 0;
   }
 
   &__name {
-    @include font($font-size-base, $font-weight-medium);
-    color: $color-text-primary;
+    font-size: $type-body-md-size;
+    font-weight: $font-weight-medium;
+    color: var(--mat-sys-on-surface);
     @include text-truncate;
 
     &--muted {
-      color: rgba($color-text-primary, 0.4);
+      color: var(--mat-sys-on-surface-variant);
       font-weight: $font-weight-regular;
     }
-  }
-}
-
-// ============================================================================
-// METHOD PILLS — HTTP method chips
-// ============================================================================
-.method-pill {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 56px;
-  padding: 5px $spacing-sm;
-  border-radius: $border-radius-base;
-  font-family: $font-family-secondary;
-  @include font($font-size-sm, $font-weight-bold);
-  letter-spacing: 0.6px;
-  color: $color-text-inverse;
-  background: $gray-400;
-  line-height: 1;
-
-  &--get {
-    background: $color-success;
-  }
-  &--post {
-    background: $color-warning;
-    color: $gray-900;
-  }
-  &--put {
-    background: $color-info;
-  }
-  &--delete {
-    background: $color-error;
-  }
-  &--patch {
-    background: $primary-300;
-  }
-  &--head {
-    background: $color-info-light;
-    color: $gray-900;
-  }
-  &--options {
-    background: $primary-200;
-    color: $gray-900;
   }
 }

--- a/src/app/features/api-routes/route-details/route-details.component.scss
+++ b/src/app/features/api-routes/route-details/route-details.component.scss
@@ -29,7 +29,7 @@
   &__path-icon {
     font-size: 1.125rem;
     line-height: 1;
-    color: var(--mat-sys-primary);
+    color: var(--mat-sys-on-surface-variant);
     flex-shrink: 0;
   }
 
@@ -37,8 +37,8 @@
     font-family: $font-family-mono;
     font-size: $type-body-lg-size;
     font-weight: $font-weight-medium;
-    color: var(--mat-sys-primary);
-    background: var(--mat-sys-primary-fixed);
+    color: var(--mat-sys-on-surface);
+    background: var(--mat-sys-surface-container);
     border: 1px solid var(--mat-sys-outline-variant);
     border-radius: $border-radius-md;
     padding: 4px $spacing-sm;
@@ -68,7 +68,7 @@
   &__icon {
     font-size: 1.125rem;
     line-height: 1;
-    color: var(--mat-sys-primary);
+    color: var(--mat-sys-on-surface-variant);
     flex-shrink: 0;
   }
 
@@ -146,14 +146,14 @@
     width: 2.25rem;
     height: 2.25rem;
     border-radius: $border-radius-md;
-    background: var(--mat-sys-primary-fixed);
+    background: var(--mat-sys-secondary-container);
     flex-shrink: 0;
     align-self: flex-start;
 
     .material-symbols-rounded {
       font-size: 1.25rem;
       line-height: 1;
-      color: var(--mat-sys-primary);
+      color: var(--mat-sys-on-secondary-container);
     }
   }
 

--- a/src/app/features/api-routes/route-details/route-details.module.ts
+++ b/src/app/features/api-routes/route-details/route-details.module.ts
@@ -14,6 +14,7 @@ import { StatTileModule } from 'src/app/shared/components/stat-tile/stat-tile.mo
 import { SectionPanelModule } from 'src/app/shared/components/section-panel/section-panel.module';
 import { StatusPillModule } from 'src/app/shared/components/status-pill/status-pill.module';
 import { EmptyStateModule } from 'src/app/shared/components/empty-state/empty-state.module';
+import { MethodPillModule } from 'src/app/shared/components/method-pill/method-pill.module';
 
 @NgModule({
   declarations: [RouteDetailsComponent],
@@ -32,6 +33,7 @@ import { EmptyStateModule } from 'src/app/shared/components/empty-state/empty-st
     SectionPanelModule,
     StatusPillModule,
     EmptyStateModule,
+    MethodPillModule,
   ],
   exports: [RouteDetailsComponent],
 })

--- a/src/app/features/api-routes/route-setup/route-setup.component.scss
+++ b/src/app/features/api-routes/route-setup/route-setup.component.scss
@@ -3,91 +3,23 @@
 
 .cluster-form {
   &__header {
-    display: flex;
-    align-items: center;
-    gap: $spacing-sm;
+    @include cluster($spacing-sm);
   }
+
   &__footer {
     margin-top: $spacing-lg;
   }
+
   &__destinations {
     margin-top: $spacing-sm;
-    @include respond-to(xs) {
-      overflow-x: scroll;
+
+    @include mobile-only {
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
     }
+
     .destinations__table {
-      width: 100%;
-      border-collapse: collapse;
-      @include card;
-      thead {
-        tr {
-          background-color: $gray-50;
-          // color: $color-text-inverse;
-          th {
-            padding: $spacing-md;
-            border: none;
-            position: relative;
-            font-weight: $font-weight-medium;
-            &::after {
-              content: '';
-              position: absolute;
-              right: 0;
-              top: 50%;
-              transform: translateY(-50%);
-              width: 1px;
-              height: 60%;
-              background-color: rgba(0, 0, 0, 0.2);
-            }
-
-            &:last-child::after {
-              display: none;
-            }
-          }
-        }
-      }
-
-      tbody {
-        tr {
-          &.bg-error {
-            background-color: rgba($color-error, 0.053);
-          }
-          td {
-            border: 1px solid $color-border;
-            padding: $spacing-md;
-            text-align: center;
-            border: none;
-            position: relative;
-            &::after {
-              content: '';
-              position: absolute;
-              right: 0;
-              top: 50%;
-              transform: translateY(-50%);
-              width: 1px;
-              height: 60%;
-              background-color: $color-border;
-            }
-
-            &:last-child::after {
-              display: none;
-            }
-            .form-field {
-              input,
-              select {
-                border: none;
-                border-bottom: 1px solid $color-border;
-                outline: none;
-                background-color: transparent;
-                @include font($font-size-xl, $font-weight-regular, $line-height-normal);
-              }
-              select {
-                cursor: pointer;
-                min-width: 120px;
-              }
-            }
-          }
-        }
-      }
+      @include form-table;
     }
   }
 }

--- a/src/app/features/sidebar/sidebar-expandable-nav-item/sidebar-expandable-nav-item.component.scss
+++ b/src/app/features/sidebar/sidebar-expandable-nav-item/sidebar-expandable-nav-item.component.scss
@@ -20,7 +20,7 @@
 :host(.host--collapsed):hover {
   .sidebar-expandable__header {
     justify-content: flex-start;
-    padding: $spacing-sm $spacing-md;
+    padding: $spacing-md $spacing-lg;
   }
 
   .sidebar-expandable__label,
@@ -30,22 +30,22 @@
 }
 
 .sidebar-expandable {
-  @include stack(2px);
+  @include stack($spacing-xs);
 
   &__header {
     display: flex;
     align-items: center;
     gap: $spacing-md;
     width: 100%;
-    padding: $spacing-sm $spacing-md;
+    padding: $spacing-md $spacing-lg;
     background: transparent;
     border: 0;
-    border-radius: $border-radius-full;
+    border-radius: $border-radius-lg;
     cursor: pointer;
     color: var(--md-on-surface-variant);
     font-family: $font-family-body;
     text-align: left;
-    transition: background-color 200ms ease, color 200ms ease, padding 200ms ease;
+    transition: transform 200ms ease, background-color 200ms ease, color 200ms ease, padding 200ms ease;
 
     @include hover-surface;
 
@@ -59,6 +59,7 @@
 
     &--group-active {
       color: var(--md-on-surface);
+      transform: translateX(0.25rem);
 
       .sidebar-expandable__icon {
         color: var(--md-secondary);

--- a/src/app/features/sidebar/sidebar-nav-link/sidebar-nav-link.component.scss
+++ b/src/app/features/sidebar/sidebar-nav-link/sidebar-nav-link.component.scss
@@ -18,7 +18,7 @@
 
 :host(.host--collapsed):hover .sidebar-nav-link {
   justify-content: flex-start;
-  padding: $spacing-sm $spacing-md;
+  padding: $spacing-md $spacing-lg;
 }
 
 :host(.host--collapsed):hover .sidebar-nav-link__label {
@@ -29,12 +29,12 @@
   display: flex;
   align-items: center;
   gap: $spacing-md;
-  padding: $spacing-sm $spacing-md;
-  border-radius: $border-radius-full;
+  padding: $spacing-md $spacing-lg;
+  border-radius: $border-radius-lg;
   color: var(--md-on-surface-variant);
   text-decoration: none;
   cursor: pointer;
-  transition: background-color 200ms ease, color 200ms ease, padding 200ms ease;
+  transition: transform 200ms ease, background-color 200ms ease, color 200ms ease, padding 200ms ease;
   font-family: $font-family-body;
 
   @include hover-surface;
@@ -67,6 +67,7 @@
   &--active {
     background: var(--md-secondary-container);
     color: var(--md-on-secondary-container);
+    transform: translateX(0.25rem);
 
     &:hover {
       background: var(--md-secondary-container);

--- a/src/app/features/sidebar/sidebar-submenu-link/sidebar-submenu-link.component.scss
+++ b/src/app/features/sidebar/sidebar-submenu-link/sidebar-submenu-link.component.scss
@@ -9,12 +9,12 @@
   display: flex;
   align-items: center;
   gap: $spacing-sm;
-  padding: 0.375rem $spacing-md;
-  border-radius: $border-radius-full;
+  padding: $spacing-md $spacing-lg;
+  border-radius: $border-radius-lg;
   color: var(--md-on-surface-variant);
   text-decoration: none;
   cursor: pointer;
-  transition: background-color 200ms ease, color 200ms ease;
+  transition: transform 200ms ease, background-color 200ms ease, color 200ms ease;
   font-family: $font-family-body;
 
   &:hover {
@@ -47,6 +47,7 @@
   &--active {
     background: var(--md-secondary-container);
     color: var(--md-on-secondary-container);
+    transform: translateX(0.25rem);
 
     .sidebar-submenu-link__icon {
       color: var(--md-on-secondary-container);

--- a/src/app/features/sidebar/sidebar.component.html
+++ b/src/app/features/sidebar/sidebar.component.html
@@ -5,13 +5,35 @@
 ></div>
 
 <aside
-  class="sidenav"
+  class="sidenav d-flex flex-column"
   [class.sidenav--collapsed]="!isMobileView && !isSidenavExpanded"
   [class.sidenav--mobile-open]="isMobileView && isSidenavExpanded"
   [attr.aria-label]="'Primary navigation'"
 >
+  <header class="sidenav__header p-lg">
+    <a class="sidenav__brand" routerLink="/dashboard" (click)="handleSidenavItemClick()">
+      <img class="sidenav__logo" src="assets/svgs/blogsphere.logo.svg" alt="logsphere" />
+      <span class="sidenav__brand-name">logsphere</span>
+    </a>
+  </header>
+
+  @if (authUser$ | async; as authUser) {
+    <section class="sidenav__welcome px-lg mb-lg">
+      <span class="sidenav__avatar" aria-hidden="true">
+        {{ (authUser.fullName || authUser.email || '?') | slice : 0 : 1 | uppercase }}
+      </span>
+      <div class="sidenav__welcome-text">
+        <span class="sidenav__welcome-label">Welcome back</span>
+        <span class="sidenav__welcome-name">{{ authUser.fullName || authUser.email }}</span>
+        @if (authUser.role) {
+          <span class="sidenav__welcome-role">{{ authUser.role }}</span>
+        }
+      </div>
+    </section>
+  }
+
   <nav class="sidenav__nav">
-    <div class="sidenav__list" role="list">
+    <div class="sidenav__list stack-xs" role="list">
       <blogsphere-sidebar-nav-link
         link="/dashboard"
         icon="dashboard"
@@ -50,4 +72,18 @@
       }
     </div>
   </nav>
+
+  <footer class="sidenav__footer p-lg">
+    <button
+      type="button"
+      class="sidenav__signout"
+      mat-ripple
+      [matRippleDisabled]="isCollapsedRail"
+      (click)="signout()"
+      [attr.aria-label]="'Sign out'"
+    >
+      <span class="material-symbols-outlined sidenav__signout-icon" aria-hidden="true">logout</span>
+      <span class="sidenav__signout-label">Sign out</span>
+    </button>
+  </footer>
 </aside>

--- a/src/app/features/sidebar/sidebar.component.scss
+++ b/src/app/features/sidebar/sidebar.component.scss
@@ -33,8 +33,6 @@
   height: 100%;
   background: var(--md-surface-container-lowest);
   border-right: 1px solid var(--md-outline-variant);
-  display: flex;
-  flex-direction: column;
   transition: width 0.25s ease-in-out, transform 0.25s ease-in-out;
 
   &--collapsed {
@@ -58,6 +56,98 @@
     }
   }
 
+  &__header {
+    flex-shrink: 0;
+  }
+
+  &__brand {
+    display: inline-flex;
+    align-items: center;
+    gap: $spacing-sm;
+    color: inherit;
+    text-decoration: none;
+    min-width: 0;
+
+    &:hover {
+      text-decoration: none;
+    }
+
+    &:focus-visible {
+      @include focus-ring;
+      border-radius: $border-radius-md;
+    }
+  }
+
+  &__logo {
+    width: 2rem;
+    height: 2rem;
+    display: block;
+    flex-shrink: 0;
+  }
+
+  &__brand-name {
+    @include type(headline-sm);
+    color: var(--md-on-surface);
+    font-family: $font-family-heading;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  &__welcome {
+    display: flex;
+    align-items: center;
+    gap: $spacing-md;
+    flex-shrink: 0;
+    min-width: 0;
+  }
+
+  &__welcome-text {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  &__avatar {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.5rem;
+    height: 2.5rem;
+    flex-shrink: 0;
+    border-radius: 50%;
+    background: var(--mat-sys-secondary-container);
+    color: var(--mat-sys-on-secondary-container);
+    font-family: $font-family-body;
+    font-size: $type-label-sm-size;
+    font-weight: $font-weight-bold;
+    text-transform: uppercase;
+  }
+
+  &__welcome-label {
+    @include type(label-xs);
+    color: var(--mat-sys-on-surface-variant);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  &__welcome-name {
+    @include type(body-md);
+    color: var(--mat-sys-on-surface);
+    font-weight: $font-weight-bold;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  &__welcome-role {
+    @include type(label-xs);
+    color: var(--mat-sys-on-surface-variant);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
   &__nav {
     flex: 1 1 auto;
     min-height: 0;
@@ -67,10 +157,103 @@
   }
 
   &__list {
-    @include stack(2px);
     list-style: none;
     margin: 0;
     padding: 0;
+  }
+
+  &__footer {
+    margin-top: auto;
+    flex-shrink: 0;
+    border-top: 1px solid var(--mat-sys-outline-variant);
+  }
+
+  &__signout {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: $spacing-sm;
+    width: 100%;
+    padding: $spacing-sm $spacing-md;
+    background: transparent;
+    border: 1.5px solid var(--mat-sys-secondary);
+    border-radius: $border-radius-lg;
+    color: var(--mat-sys-secondary);
+    font-family: $font-family-body;
+    font-weight: $font-weight-medium;
+    cursor: pointer;
+    transition: background-color 200ms ease, color 200ms ease, border-color 200ms ease;
+
+    &:hover {
+      background: var(--mat-sys-secondary-container);
+      color: var(--mat-sys-on-secondary-container);
+      border-color: var(--mat-sys-secondary-container);
+    }
+
+    &:focus-visible {
+      @include focus-ring(var(--mat-sys-secondary));
+    }
+  }
+
+  &__signout-icon {
+    font-size: 1.25rem;
+    line-height: 1;
+  }
+
+  &__signout-label {
+    @include type(body-md);
+    font-weight: $font-weight-medium;
+    line-height: 1;
+  }
+}
+
+// Collapsed (desktop rail) — hide text-only chunks; show icon-only welcome avatar + signout glyph
+:host(.host--collapsed) {
+  .sidenav__brand-name,
+  .sidenav__welcome-text,
+  .sidenav__signout-label {
+    display: none;
+  }
+
+  .sidenav__header,
+  .sidenav__footer {
+    padding-left: $spacing-sm;
+    padding-right: $spacing-sm;
+  }
+
+  .sidenav__welcome {
+    justify-content: center;
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  .sidenav__signout {
+    padding: $spacing-sm;
+  }
+
+  &:hover {
+    .sidenav__brand-name,
+    .sidenav__signout-label {
+      display: inline-block;
+    }
+
+    .sidenav__welcome-text {
+      display: flex;
+    }
+
+    .sidenav__header,
+    .sidenav__footer {
+      padding-left: $spacing-lg;
+      padding-right: $spacing-lg;
+    }
+
+    .sidenav__welcome {
+      justify-content: flex-start;
+    }
+
+    .sidenav__signout {
+      padding: $spacing-sm $spacing-md;
+    }
   }
 }
 

--- a/src/app/features/sidebar/sidebar.component.ts
+++ b/src/app/features/sidebar/sidebar.component.ts
@@ -3,7 +3,9 @@ import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
 import { AppPermission } from 'src/app/core/auth/permissions.constants';
 import { AppState } from 'src/app/store/app.state';
-import { selectHasPermission } from 'src/app/state/auth/auth.selector';
+import { AuthUser } from 'src/app/core/model/auth';
+import { AuthService } from 'src/app/core/auth/auth.service';
+import { getAuthState, selectHasPermission } from 'src/app/state/auth/auth.selector';
 import { getSidenavToggleState } from 'src/app/state/sidenav/sidenav.selector';
 import { selectMobileViewState } from 'src/app/state/mobile-view/mobile-view.selector';
 import { ToggleSideNav } from 'src/app/state/sidenav/sidenav.action';
@@ -24,6 +26,7 @@ export class SidebarComponent implements OnInit, OnDestroy {
   public canAccessUserManagement$: Observable<boolean> = this.store.select(
     selectHasPermission(AppPermission.USER_VIEW)
   );
+  public authUser$: Observable<AuthUser | null> = this.store.select(getAuthState);
 
   public subMenuList = {
     apiManager: false,
@@ -44,7 +47,10 @@ export class SidebarComponent implements OnInit, OnDestroy {
     mobileViewState: null,
   };
 
-  constructor(private store: Store<AppState>) {}
+  constructor(
+    private store: Store<AppState>,
+    private authService: AuthService
+  ) {}
 
   @HostBinding('class.host--collapsed')
   get isCollapsedRail(): boolean {
@@ -109,6 +115,10 @@ export class SidebarComponent implements OnInit, OnDestroy {
     if (this.isMobileView && this.isSidenavExpanded) {
       this.store.dispatch(new ToggleSideNav());
     }
+  }
+
+  public signout(): void {
+    this.authService.logout();
   }
 
   private updateSubmenuActions(menu: string): void {

--- a/src/app/features/subscription/api-product-create-dialog/api-product-create-dialog.component.html
+++ b/src/app/features/subscription/api-product-create-dialog/api-product-create-dialog.component.html
@@ -8,7 +8,7 @@
     </div>
     <div class="dialogue-actions">
       <span
-        class="material-symbols-outlined cursor-pointer close-icon"
+        class="material-symbols-outlined dialog-close-icon"
         (click)="closeDialog()"
         >close</span
       >

--- a/src/app/features/subscription/api-product-create-dialog/api-product-create-dialog.component.scss
+++ b/src/app/features/subscription/api-product-create-dialog/api-product-create-dialog.component.scss
@@ -1,0 +1,4 @@
+@use 'sass-utils/variables' as *;
+
+// Component-scoped styles for the dialog. Common patterns (e.g. .dialog-close-icon)
+// live in src/assets/styles/base/_prototype-utilities.scss.

--- a/src/app/features/subscription/api-product-create-dialog/api-product-create-dialog.component.scss
+++ b/src/app/features/subscription/api-product-create-dialog/api-product-create-dialog.component.scss
@@ -1,9 +1,0 @@
-@use 'sass-utils/variables' as *;
-
-.close-icon {
-  font-size: 24px;
-  transition: color 0.3s ease;
-  &:hover {
-    color: $color-error;
-  }
-}

--- a/src/app/features/subscription/api-product-create-dialog/api-product-create-dialog.component.ts
+++ b/src/app/features/subscription/api-product-create-dialog/api-product-create-dialog.component.ts
@@ -18,6 +18,7 @@ import { AppState } from 'src/app/store/app.state';
 @Component({
     selector: 'blogsphere-api-product-create-dialog',
     templateUrl: './api-product-create-dialog.component.html',
+    styleUrls: ['./api-product-create-dialog.component.scss'],
     standalone: false
 })
 export class ApiProductCreateDialogComponent implements OnInit, OnDestroy {

--- a/src/app/features/subscription/api-product-create-dialog/api-product-create-dialog.component.ts
+++ b/src/app/features/subscription/api-product-create-dialog/api-product-create-dialog.component.ts
@@ -18,7 +18,6 @@ import { AppState } from 'src/app/store/app.state';
 @Component({
     selector: 'blogsphere-api-product-create-dialog',
     templateUrl: './api-product-create-dialog.component.html',
-    styleUrls: ['./api-product-create-dialog.component.scss'],
     standalone: false
 })
 export class ApiProductCreateDialogComponent implements OnInit, OnDestroy {

--- a/src/app/features/subscription/api-product-details/api-product-details.component.scss
+++ b/src/app/features/subscription/api-product-details/api-product-details.component.scss
@@ -2,306 +2,223 @@
 @use 'sass-utils/mixins' as *;
 
 .product-details-box {
-  padding: $spacing-xl;
-  border-radius: $border-radius-lg;
-  box-shadow: 0 1px 3px $color-shadow, 0 1px 2px $color-shadow-dark;
-  overflow: hidden;
+  @include md-card($padding: $spacing-xl);
+
   .product-name {
-    display: flex;
-    align-items: center;
+    @include cluster($spacing-sm);
+
     h1 {
-      margin-top: 10px;
+      @include type(headline-md);
+      color: var(--mat-sys-on-surface);
     }
-    column-gap: 10px;
   }
+
   .product-description {
-    font-size: $font-size-2xl;
-    color: $color-text-secondary;
-    width: 50%;
-    text-wrap: wrap;
+    font-size: $type-body-md-size;
+    line-height: $type-body-md-line;
+    color: var(--mat-sys-on-surface-variant);
+    max-width: 60ch;
+    margin-top: $spacing-sm;
   }
+
   .product-creation {
-    display: flex;
-    align-items: center;
-    column-gap: 10px;
+    @include cluster($spacing-sm);
+    margin-top: $spacing-md;
+
     span {
-      font-size: $font-size-3xl;
+      font-size: $type-body-sm-size;
       font-weight: $font-weight-regular;
-      color: $color-text-secondary;
+      color: var(--mat-sys-on-surface-variant);
     }
   }
 }
-
-// ============================================================================
-// API SUBSCRIPTIONS LAYOUT
-// ============================================================================
 
 .api-subscriptions-layout {
   display: flex;
   gap: $spacing-xl;
-  min-height: 400px;
+  min-height: 25rem;
 
-  @include respond-to(xs) {
+  @include mobile-only {
+    flex-direction: column;
     gap: $spacing-lg;
-  }
-
-  @include respond-to(md) {
-    gap: $spacing-xl;
   }
 }
 
-// ============================================================================
-// PANEL SHARED STYLES
-// ============================================================================
-
 .panel-heading {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  @include heading(3);
-  color: $color-text-primary;
-  margin: 0 0 $spacing-lg 0;
+  @include row-between($spacing-sm);
+  font-family: $font-family-heading;
+  font-size: $type-headline-sm-size;
+  line-height: $type-headline-sm-line;
   font-weight: $font-weight-bold;
+  color: var(--mat-sys-on-surface);
+  margin: 0 0 $spacing-lg 0;
   padding: $spacing-md 0;
-  border-bottom: 1px solid $color-border;
-  top: 0;
-  background: $color-background;
+  border-bottom: 1px solid var(--mat-sys-outline-variant);
+  background: var(--mat-sys-surface);
+
+  @include mobile-only {
+    font-size: $type-headline-md-size;
+  }
 }
 
 .subscribed-apis-panel {
-  flex: 0 0 35%; // Left panel narrower (35%)
+  flex: 0 0 35%;
   min-width: 0;
   @include flex-column;
 
-  @include respond-to(xs) {
-    flex: 1;
-  }
-
-  @include respond-to(md) {
-    flex: 0 0 35%;
-  }
+  @include mobile-only { flex: 1; }
+  @include wide-up { flex: 0 0 30%; }
 }
 
 .subscriptions-panel {
-  flex: 0 0 60%; // Right panel wider (60%)
+  flex: 0 0 60%;
   min-width: 0;
   @include flex-column;
 
-  @include respond-to(xs) {
-    flex: 1;
-  }
-
-  @include respond-to(md) {
-    flex: 0 0 60%;
-  }
+  @include mobile-only { flex: 1; }
+  @include wide-up { flex: 0 0 65%; }
 }
-
-// ============================================================================
-// VERTICAL DIVIDER
-// ============================================================================
 
 .vertical-divider {
   width: 1px;
-  background-color: $color-border;
-  min-height: 400px;
+  background-color: var(--mat-sys-outline-variant);
+  min-height: 25rem;
 
-  @include respond-to(xs) {
-    display: none;
-  }
-
-  @include respond-to(md) {
-    display: block;
-  }
+  @include mobile-only { display: none; }
 }
-
-// ============================================================================
-// SUBSCRIBED APIS STYLES
-// ============================================================================
 
 .subscribed-apis-list {
   @include flex-column;
-  gap: $spacing-md;
   overflow-y: auto;
-  max-height: 500px;
+  max-height: 31.25rem;
+
+  @include mobile-only { max-height: none; }
 
   .api-item-box {
     padding: $spacing-lg $spacing-xl;
-    border-bottom: 1px solid $color-border;
-    // border-radius: $border-radius-base;
-    background-color: $color-background;
+    border-bottom: 1px solid var(--mat-sys-outline-variant);
+    background-color: var(--mat-sys-surface-container-lowest);
+    color: var(--mat-sys-on-surface);
+    font-size: $type-body-md-size;
+    font-weight: $font-weight-medium;
     cursor: pointer;
-    @include font($font-size-2xl, $font-weight-medium);
-    color: $color-text-primary;
-    @include transition;
+    transition: background-color 200ms ease, border-color 200ms ease;
+
     &:hover {
-      border-color: $color-primary-dark;
-      background-color: rgba($color-primary, 0.02);
+      border-color: var(--mat-sys-primary);
+      background-color: var(--mat-sys-surface-container-low);
     }
   }
 
   .api-item-box-body-action {
     margin-top: $spacing-md;
+
     span {
       padding: $spacing-md;
       border-radius: $border-radius-full;
-      background-color: $color-error;
-      color: $color-text-inverse;
-      font-size: $font-size-2xl;
-      font-weight: $font-weight-regular;
+      background-color: var(--md-status-error);
+      color: var(--mat-sys-on-primary);
+      font-size: $type-body-md-size;
       cursor: pointer;
     }
   }
 }
-
-// ============================================================================
-// SUBSCRIPTIONS STYLES
-// ============================================================================
 
 .subscriptions-list {
   position: relative;
   @include flex-column;
   gap: $spacing-lg;
   overflow-y: auto;
-  max-height: 500px;
+  max-height: 31.25rem;
+
+  @include mobile-only { max-height: none; }
 
   .subscription-card {
-    padding: 0 $spacing-xl 0 $spacing-xl;
-    border-bottom: 1px solid $color-border;
-    // border-radius: $border-radius-base;
-    background-color: $color-background;
+    padding: 0 $spacing-xl;
+    border-bottom: 1px solid var(--mat-sys-outline-variant);
+    background-color: var(--mat-sys-surface-container-lowest);
+
     .subscription-field {
-      @include flex-between;
+      @include row-between($spacing-md);
       padding: $spacing-md 0;
-      border-bottom: 1px solid rgba($color-border, 0.3);
+      border-bottom: 1px solid var(--mat-sys-surface-container);
 
       &:last-child {
         border-bottom: none;
       }
 
-      @include respond-to(xs) {
+      @include mobile-only {
         @include flex-column;
         align-items: flex-start;
         gap: $spacing-xs;
       }
+    }
 
-      @include respond-to(sm) {
-        @include flex-between;
-        gap: $spacing-md;
-      }
+    .field-label {
+      font-size: $type-body-md-size;
+      font-weight: $font-weight-bold;
+      color: var(--mat-sys-on-surface);
+      min-width: 8.75rem;
+      flex-shrink: 0;
+    }
 
-      .field-label {
-        @include font($font-size-2xl, $font-weight-bold);
-        color: $color-text-primary;
-        min-width: 140px;
-        flex-shrink: 0;
-      }
+    .field-value {
+      font-size: $type-body-md-size;
+      color: var(--mat-sys-on-surface-variant);
+      text-align: right;
+      word-break: break-word;
 
-      .field-value {
-        @include font($font-size-2xl, $font-weight-regular);
-        color: $color-text-secondary;
-        text-align: right;
-        word-break: break-word;
-
-        @include respond-to(xs) {
-          text-align: left;
-        }
-
-        @include respond-to(sm) {
-          text-align: right;
-        }
-      }
+      @include mobile-only { text-align: left; }
     }
 
     &.disabled {
-      opacity: 0.5;
-      cursor: not-allowed;
+      @include disabled-state;
     }
 
-    &--overlay{
+    &--overlay {
       position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
+      inset: 0;
       overflow: hidden;
       @include flex-center;
     }
   }
 }
 
-// ============================================================================
-// EMPTY STATE
-// ============================================================================
-
 .empty-message {
   @include flex-center;
   padding: $spacing-2xl;
-  @include font($font-size-lg, $font-weight-regular);
-  color: $color-text-disabled;
+  font-size: $type-body-md-size;
+  color: var(--mat-sys-on-surface-variant);
   font-style: italic;
   text-align: center;
 }
 
-// ============================================================================
-// RESPONSIVE ADJUSTMENTS
-// ============================================================================
-
-@include respond-to(xs) {
-  .subscribed-apis-panel,
-  .subscriptions-panel {
-    .panel-heading {
-      @include heading(4);
-      position: relative; // Not sticky on mobile
-    }
-  }
-
-  .subscribed-apis-list,
-  .subscriptions-list {
-    max-height: none; // No height limit on mobile
-  }
-}
-
-@include respond-to(lg) {
-  .subscribed-apis-panel {
-    flex: 0 0 30%; // Even narrower on large screens
-  }
-
-  .subscriptions-panel {
-    flex: 0 0 65%; // Wider on large screens
-  }
-}
-
-.mat-accordion {
-  background-color: $color-background;
+:host ::ng-deep .mat-accordion {
+  background-color: var(--mat-sys-surface);
   cursor: pointer;
-  @include font($font-size-2xl, $font-weight-medium);
-  color: $color-text-primary;
-  @include transition;
+
   .mat-expansion-panel-header {
     padding: $spacing-lg $spacing-xl;
-    &.disabled {
-      opacity: 0.5;
-    }
+
+    &.disabled { opacity: 0.5; }
   }
+
   mat-expansion-panel-body {
     position: relative;
+
     .disabled-overlay {
-      display: flex;
-      justify-content: center;
+      @include flex-center;
       align-items: start;
       position: absolute !important;
-      top: 0;
-      left: 0;
+      inset: 0;
       cursor: not-allowed !important;
-      height: 100%;
-      width: 100%;
       z-index: 2;
-      background-color: rgba($color-background, 0.8);
+      background-color: rgba($md-background, 0.8);
     }
   }
 
   .api-item-box-body {
     padding: $spacing-xs $spacing-xl;
-    font-size: $font-size-xl;
+    font-size: $type-body-lg-size;
   }
 }

--- a/src/app/features/subscription/subscribed-api-create-dialog/subscribed-api-create-dialog.component.html
+++ b/src/app/features/subscription/subscribed-api-create-dialog/subscribed-api-create-dialog.component.html
@@ -5,7 +5,7 @@
       <p class="font-size-xl">Add a new API to the product.</p>
     </div>
     <div class="dialogue-actions">
-      <span class="material-symbols-outlined cursor-pointer close-icon" (click)="closeDialog()">close</span>
+      <span class="material-symbols-outlined dialog-close-icon" (click)="closeDialog()">close</span>
     </div>
   </div>
   <div class="dialogue-body pt-xl">

--- a/src/app/features/subscription/subscribed-api-create-dialog/subscribed-api-create-dialog.component.scss
+++ b/src/app/features/subscription/subscribed-api-create-dialog/subscribed-api-create-dialog.component.scss
@@ -1,0 +1,4 @@
+@use 'sass-utils/variables' as *;
+
+// Component-scoped styles for the dialog. Common patterns (e.g. .dialog-close-icon)
+// live in src/assets/styles/base/_prototype-utilities.scss.

--- a/src/app/features/subscription/subscribed-api-create-dialog/subscribed-api-create-dialog.component.scss
+++ b/src/app/features/subscription/subscribed-api-create-dialog/subscribed-api-create-dialog.component.scss
@@ -1,9 +1,0 @@
-@use 'sass-utils/variables' as *;
-
-.close-icon {
-  font-size: 24px;
-  transition: color 0.3s ease;
-  &:hover {
-    color: $color-error;
-  }
-}

--- a/src/app/features/subscription/subscribed-api-create-dialog/subscribed-api-create-dialog.component.ts
+++ b/src/app/features/subscription/subscribed-api-create-dialog/subscribed-api-create-dialog.component.ts
@@ -27,7 +27,6 @@ import * as SubscribedApiActions from 'src/app/state/subscribed-api/subscribed-a
 @Component({
     selector: 'blogsphere-subscribed-api-create-dialog',
     templateUrl: './subscribed-api-create-dialog.component.html',
-    styleUrls: ['./subscribed-api-create-dialog.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: false
 })

--- a/src/app/features/subscription/subscribed-api-create-dialog/subscribed-api-create-dialog.component.ts
+++ b/src/app/features/subscription/subscribed-api-create-dialog/subscribed-api-create-dialog.component.ts
@@ -27,6 +27,7 @@ import * as SubscribedApiActions from 'src/app/state/subscribed-api/subscribed-a
 @Component({
     selector: 'blogsphere-subscribed-api-create-dialog',
     templateUrl: './subscribed-api-create-dialog.component.html',
+    styleUrls: ['./subscribed-api-create-dialog.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: false
 })

--- a/src/app/features/subscription/subscription-create-dialog/subscription-create-dialog.component.html
+++ b/src/app/features/subscription/subscription-create-dialog/subscription-create-dialog.component.html
@@ -5,7 +5,7 @@
       <p class="font-size-xl">Create a new subscription for the API product</p>
     </div>
     <div class="dialogue-actions">
-      <span class="material-symbols-outlined cursor-pointer close-icon" (click)="closeDialog()">close</span>
+      <span class="material-symbols-outlined dialog-close-icon" (click)="closeDialog()">close</span>
     </div>
   </div>
   <div class="dialogue-body pt-xl">

--- a/src/app/features/subscription/subscription-create-dialog/subscription-create-dialog.component.scss
+++ b/src/app/features/subscription/subscription-create-dialog/subscription-create-dialog.component.scss
@@ -1,0 +1,4 @@
+@use 'sass-utils/variables' as *;
+
+// Component-scoped styles for the dialog. Common patterns (e.g. .dialog-close-icon)
+// live in src/assets/styles/base/_prototype-utilities.scss.

--- a/src/app/features/subscription/subscription-create-dialog/subscription-create-dialog.component.scss
+++ b/src/app/features/subscription/subscription-create-dialog/subscription-create-dialog.component.scss
@@ -1,9 +1,0 @@
-@use 'sass-utils/variables' as *;
-
-.close-icon {
-  font-size: 24px;
-  transition: color 0.3s ease;
-  &:hover {
-    color: $color-error;
-  }
-}

--- a/src/app/features/subscription/subscription-create-dialog/subscription-create-dialog.component.ts
+++ b/src/app/features/subscription/subscription-create-dialog/subscription-create-dialog.component.ts
@@ -23,7 +23,6 @@ import { CreateSubscriptionRequest } from 'src/app/core/model/subscription.model
 @Component({
     selector: 'blogsphere-subscription-create-dialog',
     templateUrl: './subscription-create-dialog.component.html',
-    styleUrls: ['./subscription-create-dialog.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: false
 })

--- a/src/app/features/subscription/subscription-create-dialog/subscription-create-dialog.component.ts
+++ b/src/app/features/subscription/subscription-create-dialog/subscription-create-dialog.component.ts
@@ -23,6 +23,7 @@ import { CreateSubscriptionRequest } from 'src/app/core/model/subscription.model
 @Component({
     selector: 'blogsphere-subscription-create-dialog',
     templateUrl: './subscription-create-dialog.component.html',
+    styleUrls: ['./subscription-create-dialog.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: false
 })

--- a/src/app/features/subscription/subscription.component.scss
+++ b/src/app/features/subscription/subscription.component.scss
@@ -2,7 +2,7 @@
 @use 'sass-utils/mixins' as *;
 
 .subscription-empty {
-  min-height: 240px;
+  min-height: 15rem;
   padding: $spacing-2xl 0;
 
   &__content {
@@ -11,27 +11,25 @@
 }
 
 .loading-state {
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  @include flex-center;
   height: 100%;
 }
 
 .loading-state-content {
   text-align: center;
   padding: $spacing-lg;
-}
 
-.loading-state-content-icon {
-  font-size: $font-size-5xl;
-  color: $color-primary;
-}
+  &-icon {
+    font-size: $font-size-5xl;
+    color: var(--mat-sys-primary);
+  }
 
-.loading-state-content-text {
-  font-size: $font-size-xl;
-  color: $color-text-primary;
-}
+  &-text {
+    font-size: $type-body-lg-size;
+    color: var(--mat-sys-on-surface);
+  }
 
-.loading-state-content-spinner {
-  margin-top: $spacing-lg;
+  &-spinner {
+    margin-top: $spacing-lg;
+  }
 }

--- a/src/app/shared/components/badge/badge.component.scss
+++ b/src/app/shared/components/badge/badge.component.scss
@@ -1,36 +1,47 @@
 @use 'sass-utils/variables' as *;
-@use 'sass-utils/functions' as *;
+@use 'sass-utils/mixins' as *;
 
 .badge {
-  display: inline-block;
-  padding: $spacing-xs $spacing-sm;
-  font-size: $font-size-base;
-  font-weight: $font-weight-medium;
-  line-height: $line-height-normal;
-  text-align: center;
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-xs;
+  padding: 2px $spacing-sm;
+  border-radius: $border-radius-base;
+  font-family: $font-family-body;
+  font-size: $type-label-xs-size;
+  line-height: $type-label-xs-line;
+  font-weight: $type-label-xs-weight;
+  letter-spacing: $type-label-xs-tracking;
+  text-transform: uppercase;
   white-space: nowrap;
   vertical-align: middle;
+
   &.rounded-pill {
-    border-radius: $border-radius-md;
+    border-radius: $border-radius-full;
   }
+
   &--primary {
-    color: $color-primary;
-    background-color: tint($color-primary, 80%);
+    background: var(--mat-sys-primary-container);
+    color: var(--mat-sys-on-primary-container);
   }
+
   &--secondary {
-    color: $color-accent;
-    background-color: tint($color-accent, 80%);
+    background: var(--mat-sys-secondary-container);
+    color: var(--mat-sys-on-secondary-container);
   }
+
   &--success {
-    color: $color-success;
-    background-color: tint($color-success, 80%);
+    background: var(--md-status-success-container);
+    color: var(--md-status-success);
   }
+
   &--danger {
-    color: $color-error;
-    background-color: tint($color-error, 80%);
+    background: var(--md-status-error-container);
+    color: var(--md-status-error);
   }
+
   &--warning {
-    color: $color-warning;
-    background-color: tint($color-warning, 80%);
+    background: var(--md-status-warning-container);
+    color: var(--md-status-warning);
   }
 }

--- a/src/app/shared/components/badge/badge.component.scss
+++ b/src/app/shared/components/badge/badge.component.scss
@@ -16,6 +16,17 @@
   white-space: nowrap;
   vertical-align: middle;
 
+  // Sizing for projected leading icons (e.g. <span class="material-symbols-outlined">check</span>).
+  // ::ng-deep penetrates view encapsulation so the consumer's icon glyph picks up these styles;
+  // the direct-child selector is the encapsulated fallback for the same-template case.
+  ::ng-deep .material-symbols-outlined,
+  ::ng-deep .material-symbols-rounded,
+  & > .material-symbols-outlined,
+  & > .material-symbols-rounded {
+    font-size: 1rem;
+    line-height: 1;
+  }
+
   &.rounded-pill {
     border-radius: $border-radius-full;
   }

--- a/src/app/shared/components/chart-card/chart-card.component.spec.ts
+++ b/src/app/shared/components/chart-card/chart-card.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ChartCardComponent } from './chart-card.component';
+import { ChartCardModule } from './chart-card.module';
+
+describe('ChartCardComponent', () => {
+  let component: ChartCardComponent;
+  let fixture: ComponentFixture<ChartCardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ChartCardModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ChartCardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/icon-button/icon-button.component.spec.ts
+++ b/src/app/shared/components/icon-button/icon-button.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { IconButtonComponent } from './icon-button.component';
+import { IconButtonModule } from './icon-button.module';
+
+describe('IconButtonComponent', () => {
+  let component: IconButtonComponent;
+  let fixture: ComponentFixture<IconButtonComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [IconButtonModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(IconButtonComponent);
+    component = fixture.componentInstance;
+    component.icon = 'home';
+    component.ariaLabel = 'Home';
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/method-pill/method-pill.component.html
+++ b/src/app/shared/components/method-pill/method-pill.component.html
@@ -1,0 +1,7 @@
+<span
+  class="method-pill"
+  [ngClass]="[toneClass, 'method-pill--size-' + size]"
+  [attr.aria-label]="'HTTP method ' + methodUpper"
+>
+  {{ methodUpper }}
+</span>

--- a/src/app/shared/components/method-pill/method-pill.component.scss
+++ b/src/app/shared/components/method-pill/method-pill.component.scss
@@ -1,0 +1,39 @@
+@use 'sass-utils/variables' as *;
+@use 'sass-utils/mixins' as *;
+
+:host {
+  display: inline-flex;
+}
+
+.method-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 3.5rem;
+  padding: 5px $spacing-sm;
+  border-radius: $border-radius-base;
+  font-family: $font-family-body;
+  font-size: $type-label-xs-size;
+  font-weight: $font-weight-bold;
+  letter-spacing: 0.6px;
+  line-height: 1;
+  color: var(--mat-sys-on-primary);
+  background: var(--mat-sys-outline);
+  text-transform: uppercase;
+  white-space: nowrap;
+
+  &--get     { background: var(--md-status-success); color: var(--mat-sys-on-primary); }
+  &--post    { background: var(--md-status-warning); color: var(--mat-sys-on-surface); }
+  &--put     { background: var(--md-status-info); color: var(--mat-sys-on-primary); }
+  &--delete  { background: var(--md-status-error); color: var(--mat-sys-on-primary); }
+  &--patch   { background: var(--mat-sys-secondary); color: var(--mat-sys-on-secondary); }
+  &--head    { background: var(--md-status-info-container); color: var(--md-status-info); }
+  &--options { background: var(--mat-sys-tertiary-container); color: var(--mat-sys-on-tertiary-container); }
+  &--unknown { background: var(--mat-sys-outline); color: var(--mat-sys-on-primary); }
+
+  &--size-sm {
+    min-width: 3rem;
+    padding: 3px $spacing-xs;
+    font-size: 0.6875rem;
+  }
+}

--- a/src/app/shared/components/method-pill/method-pill.component.spec.ts
+++ b/src/app/shared/components/method-pill/method-pill.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MethodPillComponent } from './method-pill.component';
+import { MethodPillModule } from './method-pill.module';
+
+describe('MethodPillComponent', () => {
+  let component: MethodPillComponent;
+  let fixture: ComponentFixture<MethodPillComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MethodPillModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MethodPillComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/method-pill/method-pill.component.ts
+++ b/src/app/shared/components/method-pill/method-pill.component.ts
@@ -1,0 +1,24 @@
+import { Component, Input } from '@angular/core';
+
+export type MethodPillSize = 'sm' | 'md';
+
+@Component({
+  selector: 'blogsphere-method-pill',
+  templateUrl: './method-pill.component.html',
+  styleUrls: ['./method-pill.component.scss'],
+  standalone: false,
+})
+export class MethodPillComponent {
+  @Input() method = '';
+  @Input() size: MethodPillSize = 'md';
+
+  public get methodUpper(): string {
+    return (this.method || '').toUpperCase();
+  }
+
+  public get toneClass(): string {
+    const known = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS'];
+    const m = this.methodUpper;
+    return known.includes(m) ? `method-pill--${m.toLowerCase()}` : 'method-pill--unknown';
+  }
+}

--- a/src/app/shared/components/method-pill/method-pill.module.ts
+++ b/src/app/shared/components/method-pill/method-pill.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MethodPillComponent } from './method-pill.component';
+
+@NgModule({
+  declarations: [MethodPillComponent],
+  imports: [CommonModule],
+  exports: [MethodPillComponent],
+})
+export class MethodPillModule {}

--- a/src/app/shared/components/metric-card/metric-card.component.spec.ts
+++ b/src/app/shared/components/metric-card/metric-card.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MetricCardComponent } from './metric-card.component';
+import { MetricCardModule } from './metric-card.module';
+
+describe('MetricCardComponent', () => {
+  let component: MetricCardComponent;
+  let fixture: ComponentFixture<MetricCardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MetricCardModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MetricCardComponent);
+    component = fixture.componentInstance;
+    component.label = 'Total';
+    component.value = '0';
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/navbar/navbar.component.html
+++ b/src/app/shared/components/navbar/navbar.component.html
@@ -10,10 +10,6 @@
         (next)="toggleSidenav()"
       ></blogsphere-icon-button>
     }
-    <a class="topbar__brand-mark" [class.topbar__brand-mark--shift]="isProfilePage" routerLink="/dashboard">
-      <img class="topbar__logo" src="../../../../assets/svgs/blogsphere.logo.svg" alt="Blogsphere" />
-      <span class="topbar__name">logsphere</span>
-    </a>
   </div>
 
   @if (!(isMobileView$ | async) && !maintenanceMode && !isProfilePage) {
@@ -34,22 +30,6 @@
         variant="ghost"
         tone="on-surface"
       ></blogsphere-icon-button>
-
-      <button
-        type="button"
-        class="topbar__profile"
-        [matMenuTriggerFor]="userActionMenu"
-        #userMenuTrigger="matMenuTrigger"
-        [attr.aria-label]="'Account menu for ' + ((authUser$ | async)?.email)"
-      >
-        <span class="topbar__avatar" aria-hidden="true">
-          {{ ((authUser$ | async)?.email || '?') | slice : 0 : 1 | uppercase }}
-        </span>
-        <span class="topbar__profile-email">{{ (authUser$ | async)?.email }}</span>
-        <span class="material-symbols-rounded topbar__profile-chevron" aria-hidden="true">{{
-          userMenuTrigger.menuOpen ? 'keyboard_arrow_up' : 'keyboard_arrow_down'
-        }}</span>
-      </button>
     </div>
   }
 
@@ -87,14 +67,3 @@
     </mat-accordion>
   </div>
 }
-
-<mat-menu #userActionMenu="matMenu" class="topbar__menu-panel">
-  <button type="button" mat-menu-item (click)="navigateToUserProfile()">
-    <span class="material-symbols-rounded" aria-hidden="true">person</span>
-    <span>My profile</span>
-  </button>
-  <button type="button" mat-menu-item (click)="signout()">
-    <span class="material-symbols-rounded" aria-hidden="true">power_settings_new</span>
-    <span>Logout</span>
-  </button>
-</mat-menu>

--- a/src/app/shared/components/navbar/navbar.component.scss
+++ b/src/app/shared/components/navbar/navbar.component.scss
@@ -26,97 +26,10 @@
     min-width: 0;
   }
 
-  &__brand-mark {
-    display: inline-flex;
-    align-items: center;
-    gap: $spacing-xs;
-    color: inherit;
-    text-decoration: none;
-
-    &:hover { text-decoration: none; }
-
-    &--shift {
-      margin-left: $spacing-md;
-    }
-  }
-
-  &__logo {
-    width: 1.75rem;
-    height: 1.75rem;
-    display: block;
-  }
-
-  &__name {
-    @include type(headline-sm);
-    color: var(--md-on-surface);
-    font-family: $font-family-heading;
-
-    @include respond-to(sm) {
-      display: none;
-    }
-  }
-
   &__actions {
     display: flex;
     align-items: center;
     gap: $spacing-xs;
-  }
-
-  &__profile {
-    display: inline-flex;
-    align-items: center;
-    gap: $spacing-sm;
-    padding: $spacing-xs $spacing-sm;
-    background: transparent;
-    border: 1px solid transparent;
-    border-radius: $border-radius-full;
-    cursor: pointer;
-    transition: background-color 200ms ease, border-color 200ms ease;
-    font-family: $font-family-body;
-    color: var(--md-on-surface);
-    margin-left: $spacing-sm;
-
-    &:hover {
-      background: var(--md-surface-container);
-    }
-
-    &:focus-visible {
-      outline: 2px solid var(--md-primary);
-      outline-offset: 2px;
-    }
-  }
-
-  &__avatar {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 2rem;
-    height: 2rem;
-    border-radius: 50%;
-    background: var(--md-primary-fixed);
-    color: var(--md-on-primary-fixed);
-    font-size: $type-label-sm-size;
-    font-weight: $font-weight-bold;
-  }
-
-  &__profile-email {
-    @include type(body-sm);
-    font-weight: $font-weight-medium;
-    color: var(--md-on-surface);
-    max-width: 18ch;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-
-    @include respond-to(md) {
-      display: none;
-    }
-  }
-
-  &__profile-chevron {
-    color: var(--md-on-surface-variant);
-    font-size: 1.25rem;
-    line-height: 1;
   }
 
   &__mobile {

--- a/src/app/shared/components/navbar/navbar.component.ts
+++ b/src/app/shared/components/navbar/navbar.component.ts
@@ -5,7 +5,6 @@ import { selectMobileViewState } from 'src/app/state/mobile-view/mobile-view.sel
 import { MatExpansionPanel } from '@angular/material/expansion';
 import { ToggleSideNav } from 'src/app/state/sidenav/sidenav.action';
 import { AuthService } from 'src/app/core/auth/auth.service';
-import { getAuthState } from 'src/app/state/auth/auth.selector';
 import { environment } from 'src/environments/environment';
 import { Router } from '@angular/router';
 
@@ -21,7 +20,6 @@ export class NavbarComponent implements OnInit {
   @Input() public isProfilePage: boolean = false;
 
   public isMobileView$ = this.store.select(selectMobileViewState);
-  public authUser$ = this.store.select(getAuthState);
   public maintenanceMode: boolean = environment.maintenanceMode;
 
   constructor(

--- a/src/app/shared/components/paginator/paginator.component.scss
+++ b/src/app/shared/components/paginator/paginator.component.scss
@@ -1,226 +1,124 @@
 @use 'sass-utils/variables' as *;
 @use 'sass-utils/mixins' as *;
 
+:host {
+  display: block;
+}
+
 .pagination-wrapper {
-  margin-top: $spacing-2xl;
-  padding: $spacing-lg 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: $spacing-sm;
+  padding: $spacing-md $spacing-lg;
+  background: var(--mat-sys-surface-container-low);
+  border-top: 1px solid var(--mat-sys-outline-variant);
 
-  .custom-pagination {
-    display: flex;
-    justify-content: center;
-    margin-bottom: $spacing-lg;
+  @include tablet-up {
+    flex-direction: row;
+    justify-content: space-between;
+    gap: $spacing-md;
+  }
+}
 
-    .pagination-list {
-      display: flex;
-      align-items: center;
-      gap: $spacing-xs;
-      list-style: none;
-      margin: 0;
-      padding: 0;
-      flex-wrap: wrap;
-      justify-content: center;
+.custom-pagination {
+  display: flex;
+}
 
-      .pagination-item {
-        margin: 0;
+.pagination-list {
+  display: flex;
+  align-items: center;
+  gap: $spacing-xs;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  flex-wrap: wrap;
+  justify-content: center;
+}
 
-        .pagination-link {
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          min-width: 40px;
-          height: 40px;
-          padding: $spacing-sm;
-          border: 1px solid $color-border;
-          background-color: $color-background;
-          color: $color-primary;
-          text-decoration: none;
-          border-radius: $border-radius-md;
-          font-weight: $font-weight-medium;
-          font-size: $font-size-base!important;
-          cursor: pointer;
-          transition: all 0.2s ease-in-out;
-          user-select: none;
+.pagination-item {
+  margin: 0;
+}
 
-          &:hover:not(:disabled) {
-            background-color: $color-primary;
-            color: $color-background;
-            border-color: $color-primary;
-            transform: translateY(-1px);
-            box-shadow: 0 4px 8px $color-shadow;
-          }
+.pagination-link {
+  @include flex-center;
+  min-width: 2.25rem;
+  height: 2.25rem;
+  padding: 0 $spacing-sm;
+  border: 1px solid transparent;
+  background: var(--mat-sys-surface-container-lowest);
+  color: var(--mat-sys-on-surface);
+  text-decoration: none;
+  border-radius: $border-radius-base;
+  font-family: $font-family-body;
+  font-size: $type-label-sm-size;
+  line-height: $type-label-sm-line;
+  font-weight: $font-weight-medium;
+  cursor: pointer;
+  transition: background-color 200ms ease, color 200ms ease, border-color 200ms ease;
+  user-select: none;
 
-          &:active:not(:disabled) {
-            transform: translateY(0);
-            box-shadow: 0 2px 4px $color-shadow;
-          }
+  &:hover:not(:disabled):not(.active) {
+    background: var(--mat-sys-surface-container);
+    border-color: var(--mat-sys-outline-variant);
+  }
 
-          &.active {
-            background-color: $color-primary;
-            color: $color-background;
-            border-color: $color-primary;
-            box-shadow: 0 2px 8px $color-shadow;
-            font-weight: $font-weight-bold;
-          }
+  &:focus-visible {
+    @include focus-ring(var(--mat-sys-secondary));
+  }
 
-          &:disabled {
-            opacity: 0.4;
-            cursor: not-allowed;
-            background-color: $color-background-secondary;
-            color: $color-text-disabled;
-            border-color: $color-border-light;
+  &.active {
+    background: var(--mat-sys-secondary-container);
+    color: var(--mat-sys-on-secondary-container);
+    border-color: var(--mat-sys-secondary-container);
+    font-weight: $font-weight-bold;
+  }
 
-            &:hover {
-              transform: none;
-              box-shadow: none;
-            }
-          }
+  &:disabled {
+    @include disabled-state;
+    border-color: transparent;
+  }
 
-          &.pagination-control {
-            .material-symbols-outlined {
-              font-size: 20px;
-            }
-          }
+  &.pagination-control .material-symbols-outlined {
+    font-size: 1.25rem;
+  }
+}
 
-          // Focus styles for accessibility
-          &:focus {
-            outline: 2px solid $color-primary;
-            outline-offset: 2px;
-          }
-        }
+.pagination-ellipsis {
+  @include flex-center;
+  min-width: 2.25rem;
+  height: 2.25rem;
+  color: var(--mat-sys-on-surface-variant);
+  font-weight: $font-weight-medium;
+  font-size: $type-label-sm-size;
+  user-select: none;
+}
 
-        .pagination-ellipsis {
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          min-width: 40px;
-          height: 40px;
-          padding: $spacing-sm;
-          color: $color-text-disabled;
-          font-weight: $font-weight-medium;
-          font-size: $font-size-sm;
-          user-select: none;
-        }
-      }
-    }
+.page-info {
+  font-family: $font-family-body;
+  font-size: $type-label-sm-size;
+  line-height: $type-label-sm-line;
+  color: var(--mat-sys-on-surface-variant);
+
+  span {
+    display: inline-block;
+  }
+}
+
+@include mobile-only {
+  .pagination-link,
+  .pagination-ellipsis {
+    min-width: 2rem;
+    height: 2rem;
+    font-size: $type-label-xs-size;
+  }
+
+  .pagination-link.pagination-control .material-symbols-outlined {
+    font-size: 1rem;
   }
 
   .page-info {
+    font-size: $type-label-xs-size;
     text-align: center;
-    color: $color-text-secondary;
-    font-size: $font-size-base!important;
-    font-weight: $font-weight-normal;
-
-    span {
-      background-color: $color-background-secondary;
-      padding: $spacing-sm $spacing-md;
-      border-radius: $border-radius-md;
-      border: 1px solid $color-border-light;
-    }
-  }
-}
-
-// ============================================================================
-// RESPONSIVE PAGINATION STYLES
-// ============================================================================
-
-@include respond-to(md) {
-  .pagination-wrapper {
-    .custom-pagination {
-      .pagination-list {
-        gap: $spacing-sm;
-
-        .pagination-item {
-          .pagination-link {
-            min-width: 36px;
-            height: 36px;
-            font-size: $font-size-xs;
-          }
-
-          .pagination-ellipsis {
-            min-width: 36px;
-            height: 36px;
-            font-size: $font-size-xs;
-          }
-        }
-      }
-    }
-
-    .page-info {
-      font-size: $font-size-xs;
-
-      span {
-        padding: $spacing-xs $spacing-sm;
-      }
-    }
-  }
-}
-
-@include respond-to(sm) {
-  .pagination-wrapper {
-    .custom-pagination {
-      .pagination-list {
-        gap: 2px;
-
-        .pagination-item {
-          .pagination-link {
-            min-width: 32px;
-            height: 32px;
-            padding: $spacing-xs;
-            font-size: $font-size-xs;
-
-            &.pagination-control {
-              .material-symbols-outlined {
-                font-size: 16px;
-              }
-            }
-          }
-
-          .pagination-ellipsis {
-            min-width: 32px;
-            height: 32px;
-            font-size: $font-size-xs;
-          }
-        }
-      }
-    }
-
-    .page-info {
-      margin-top: $spacing-sm;
-
-      span {
-        display: inline-block;
-        word-break: break-word;
-      }
-    }
-  }
-}
-
-// ============================================================================
-// ANIMATION UTILITIES
-// ============================================================================
-
-@keyframes pagination-pulse {
-  0% {
-    box-shadow: 0 0 0 0 rgba($color-primary, 0.4);
-  }
-  70% {
-    box-shadow: 0 0 0 10px rgba($color-primary, 0);
-  }
-  100% {
-    box-shadow: 0 0 0 0 rgba($color-primary, 0);
-  }
-}
-
-.pagination-wrapper {
-  .custom-pagination {
-    .pagination-list {
-      .pagination-item {
-        .pagination-link {
-          &.loading {
-            animation: pagination-pulse 1.5s infinite;
-          }
-        }
-      }
-    }
   }
 }

--- a/src/app/shared/components/progress-bar/progress-bar.component.spec.ts
+++ b/src/app/shared/components/progress-bar/progress-bar.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ProgressBarComponent } from './progress-bar.component';
+import { ProgressBarModule } from './progress-bar.module';
+
+describe('ProgressBarComponent', () => {
+  let component: ProgressBarComponent;
+  let fixture: ComponentFixture<ProgressBarComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ProgressBarModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ProgressBarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/quick-action-tile/quick-action-tile.component.spec.ts
+++ b/src/app/shared/components/quick-action-tile/quick-action-tile.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { QuickActionTileComponent } from './quick-action-tile.component';
+import { QuickActionTileModule } from './quick-action-tile.module';
+
+describe('QuickActionTileComponent', () => {
+  let component: QuickActionTileComponent;
+  let fixture: ComponentFixture<QuickActionTileComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [QuickActionTileModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(QuickActionTileComponent);
+    component = fixture.componentInstance;
+    component.icon = 'home';
+    component.label = 'Home';
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/segmented-control/segmented-control.component.spec.ts
+++ b/src/app/shared/components/segmented-control/segmented-control.component.spec.ts
@@ -1,0 +1,27 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SegmentedControlComponent } from './segmented-control.component';
+import { SegmentedControlModule } from './segmented-control.module';
+
+describe('SegmentedControlComponent', () => {
+  let component: SegmentedControlComponent;
+  let fixture: ComponentFixture<SegmentedControlComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SegmentedControlModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SegmentedControlComponent);
+    component = fixture.componentInstance;
+    component.options = [
+      { id: '7d', label: '7d' },
+      { id: '30d', label: '30d' },
+    ];
+    component.value = '7d';
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/status-pill/status-pill.component.spec.ts
+++ b/src/app/shared/components/status-pill/status-pill.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { StatusPillComponent } from './status-pill.component';
+import { StatusPillModule } from './status-pill.module';
+
+describe('StatusPillComponent', () => {
+  let component: StatusPillComponent;
+  let fixture: ComponentFixture<StatusPillComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [StatusPillModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(StatusPillComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/table/table.component.html
+++ b/src/app/shared/components/table/table.component.html
@@ -1,53 +1,55 @@
-<table class="table__layout" cdk-table [dataSource]="tableDataSource">
-  @for (col of columns; track col) {
-    <ng-container [cdkColumnDef]="col">
-      <th class="table__header-cell" cdk-header-cell *cdkHeaderCellDef>
-        {{ columnMap ? (getColumnKey(col) | capitalize) : (col | capitalize) }}
-      </th>
-      <td class="table__cell" cdk-cell *cdkCellDef="let element; let i = index">
-        @if (col !== 'actions') {
-          @if (isStatusField(col)) {
-            <blogsphere-badge
-              [type]="element[getColumnValue(col)] === 'Active' ? BadgeType.success : BadgeType.danger"
-              [isRounded]="true"
+<div class="table__scroll">
+  <table class="table__layout" cdk-table [dataSource]="tableDataSource">
+    @for (col of columns; track col) {
+      <ng-container [cdkColumnDef]="col">
+        <th class="table__header-cell" cdk-header-cell *cdkHeaderCellDef>
+          {{ columnMap ? (getColumnKey(col) | capitalize) : (col | capitalize) }}
+        </th>
+        <td class="table__cell" cdk-cell *cdkCellDef="let element; let i = index">
+          @if (col !== 'actions') {
+            @if (isStatusField(col)) {
+              <blogsphere-badge
+                [type]="element[getColumnValue(col)] === 'Active' ? BadgeType.success : BadgeType.danger"
+                [isRounded]="true"
               >
-              {{ element[getColumnValue(col)] }}
-            </blogsphere-badge>
+                {{ element[getColumnValue(col)] }}
+              </blogsphere-badge>
+            }
+            @if (isLinkField(col)) {
+              <a (click)="onLinkClick(element)">{{ element[getColumnValue(col)] }}</a>
+            }
+            @if (!isStatusField(col) && !isLinkField(col)) {
+              {{
+              !columnMap
+              ? element[col]
+              : isDateField(col)
+              ? (element[getColumnValue(col)] | formatDate | formatStatus)
+              : element[getColumnValue(col)]
+              }}
+            }
+          } @else {
+            <div class="custom-menu" matRipple [matMenuTriggerFor]="actionMenu" aria-label="Row actions">
+              <span class="material-symbols-outlined">more_horiz</span>
+              <mat-menu #actionMenu="matMenu" xPosition="before">
+                @if (allowVisit) {
+                  <button mat-menu-item (click)="onVisit(element)">Visit</button>
+                }
+                @if (allowEdit) {
+                  <button mat-menu-item (click)="onEdit(element)">Edit</button>
+                }
+                @if (allowDelete) {
+                  <button mat-menu-item (click)="onDelete(element)">Delete</button>
+                }
+              </mat-menu>
+            </div>
           }
-          @if (isLinkField(col)) {
-            <a (click)="onLinkClick(element)">{{ element[getColumnValue(col)] }}</a>
-          }
-          @if (!isStatusField(col) && !isLinkField(col)) {
-            {{
-            !columnMap
-            ? element[col]
-            : isDateField(col)
-            ? (element[getColumnValue(col)] | formatDate | formatStatus)
-            : element[getColumnValue(col)]
-            }}
-          }
-        } @else {
-          <div class="custom-menu" matRipple [matMenuTriggerFor]="actionMenu">
-            <span class="material-symbols-outlined">more_horiz</span>
-            <mat-menu #actionMenu="matMenu" xPosition="before">
-              @if (allowVisit) {
-                <button mat-menu-item (click)="onVisit(element)">Visit</button>
-              }
-              @if (allowEdit) {
-                <button mat-menu-item (click)="onEdit(element)">Edit</button>
-              }
-              @if (allowDelete) {
-                <button mat-menu-item (click)="onDelete(element)">Delete</button>
-              }
-            </mat-menu>
-          </div>
-        }
-      </td>
-    </ng-container>
-  }
-  <tr class="table__header-row" cdk-header-row *cdkHeaderRowDef="columns"></tr>
-  <tr class="table__row" cdk-row *cdkRowDef="let row; columns: columns"></tr>
-</table>
+        </td>
+      </ng-container>
+    }
+    <tr class="table__header-row" cdk-header-row *cdkHeaderRowDef="columns"></tr>
+    <tr class="table__row" cdk-row *cdkRowDef="let row; columns: columns"></tr>
+  </table>
+</div>
 
 @if (dataLength > 0) {
   <blogsphere-paginator
@@ -55,11 +57,3 @@
     (pageChange)="onPageChange($event)"
   ></blogsphere-paginator>
 }
-
-<!-- <mat-paginator
-[length]="dataLength"
-[pageIndex]="paginationMetadata.currentPage - 1"
-[pageSize]="paginationMetadata.top"
-[pageSizeOptions]="[10, 20, 50, 100]"
-(page)="onPageChange($event)"
-></mat-paginator> -->

--- a/src/app/shared/components/table/table.component.html
+++ b/src/app/shared/components/table/table.component.html
@@ -1,3 +1,14 @@
+@if (showHeader) {
+  <div class="table__header-strip row-between px-lg py-md">
+    <div class="table__header-strip-title">
+      <ng-content select="[tableHeader]"></ng-content>
+    </div>
+    <div class="table__header-strip-actions">
+      <ng-content select="[tableHeaderActions]"></ng-content>
+    </div>
+  </div>
+}
+
 <div class="table__scroll">
   <table class="table__layout" cdk-table [dataSource]="tableDataSource">
     @for (col of columns; track col) {
@@ -5,7 +16,12 @@
         <th class="table__header-cell" cdk-header-cell *cdkHeaderCellDef>
           {{ columnMap ? (getColumnKey(col) | capitalize) : (col | capitalize) }}
         </th>
-        <td class="table__cell" cdk-cell *cdkCellDef="let element; let i = index">
+        <td
+          class="table__cell"
+          [class.is-bold]="boldColumns.includes(col)"
+          cdk-cell
+          *cdkCellDef="let element; let i = index"
+        >
           @if (col !== 'actions') {
             @if (isStatusField(col)) {
               <blogsphere-badge
@@ -28,20 +44,24 @@
               }}
             }
           } @else {
-            <div class="custom-menu" matRipple [matMenuTriggerFor]="actionMenu" aria-label="Row actions">
-              <span class="material-symbols-outlined">more_horiz</span>
-              <mat-menu #actionMenu="matMenu" xPosition="before">
-                @if (allowVisit) {
-                  <button mat-menu-item (click)="onVisit(element)">Visit</button>
-                }
-                @if (allowEdit) {
-                  <button mat-menu-item (click)="onEdit(element)">Edit</button>
-                }
-                @if (allowDelete) {
-                  <button mat-menu-item (click)="onDelete(element)">Delete</button>
-                }
-              </mat-menu>
-            </div>
+            @if (actionTemplate) {
+              <ng-container *ngTemplateOutlet="actionTemplate; context: { $implicit: element }"></ng-container>
+            } @else {
+              <div class="custom-menu" matRipple [matMenuTriggerFor]="actionMenu" aria-label="Row actions">
+                <span class="material-symbols-outlined">more_horiz</span>
+                <mat-menu #actionMenu="matMenu" xPosition="before">
+                  @if (allowVisit) {
+                    <button mat-menu-item (click)="onVisit(element)">Visit</button>
+                  }
+                  @if (allowEdit) {
+                    <button mat-menu-item (click)="onEdit(element)">Edit</button>
+                  }
+                  @if (allowDelete) {
+                    <button mat-menu-item (click)="onDelete(element)">Delete</button>
+                  }
+                </mat-menu>
+              </div>
+            }
           }
         </td>
       </ng-container>
@@ -50,6 +70,12 @@
     <tr class="table__row" cdk-row *cdkRowDef="let row; columns: columns"></tr>
   </table>
 </div>
+
+@if (showFooter) {
+  <div class="table__footer-row">
+    <ng-content select="[tableFooter]"></ng-content>
+  </div>
+}
 
 @if (dataLength > 0) {
   <blogsphere-paginator

--- a/src/app/shared/components/table/table.component.scss
+++ b/src/app/shared/components/table/table.component.scss
@@ -10,6 +10,21 @@
   overflow: hidden;
 }
 
+.table__header-strip {
+  border-bottom: 1px solid var(--mat-sys-outline-variant);
+}
+
+.table__header-strip-title {
+  min-width: 0;
+}
+
+.table__header-strip-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-sm;
+  flex-shrink: 0;
+}
+
 .table__scroll {
   width: 100%;
   overflow-x: auto;
@@ -23,14 +38,10 @@
   background: transparent;
 }
 
-.table__header-row {
-  background: var(--mat-sys-surface-container);
-}
-
 .table__header-cell {
   @include eyebrow-label(var(--mat-sys-on-surface-variant));
   text-align: left;
-  padding: $spacing-md $spacing-lg;
+  padding: $spacing-lg;
   border-bottom: 1px solid var(--mat-sys-outline-variant);
   white-space: nowrap;
 
@@ -50,11 +61,15 @@
 .table__cell {
   @include type(body-md);
   color: var(--mat-sys-on-surface);
-  padding: $spacing-md $spacing-lg;
+  padding: $spacing-lg;
   border-bottom: 1px solid var(--mat-sys-outline-variant);
   vertical-align: middle;
 
   &:first-child {
+    font-weight: $font-weight-bold;
+  }
+
+  &.is-bold {
     font-weight: $font-weight-bold;
   }
 
@@ -88,6 +103,44 @@
   padding: $spacing-3xl $spacing-md;
   color: var(--mat-sys-on-surface-variant);
   @include type(body-md);
+}
+
+.table__footer-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: $spacing-md;
+  background: var(--mat-sys-surface-container-low);
+  border-top: 1px solid var(--mat-sys-outline-variant);
+  color: var(--mat-sys-secondary);
+  @include type(label-sm);
+  font-weight: $font-weight-medium;
+}
+
+.table__link-action {
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-xs;
+  color: var(--mat-sys-secondary);
+  font-weight: $font-weight-medium;
+  text-decoration: none;
+  cursor: pointer;
+  transition: color 200ms ease;
+
+  &:hover {
+    text-decoration: underline;
+    color: var(--mat-sys-secondary);
+  }
+
+  &:focus-visible {
+    @include focus-ring(var(--mat-sys-secondary));
+    border-radius: $border-radius-sm;
+  }
+
+  .material-symbols-outlined {
+    font-size: 1rem;
+    line-height: 1;
+  }
 }
 
 .custom-menu {

--- a/src/app/shared/components/table/table.component.scss
+++ b/src/app/shared/components/table/table.component.scss
@@ -1,205 +1,131 @@
 @use 'sass-utils/variables' as *;
 @use 'sass-utils/mixins' as *;
 
-// ============================================================================
-// TABLE COMPONENT - BLOGSPHERE THEME
-// ============================================================================
+:host {
+  display: block;
+  background: var(--mat-sys-surface-container-lowest);
+  border: 1px solid var(--mat-sys-outline-variant);
+  border-radius: $border-radius-lg;
+  box-shadow: var(--md-elevation-card);
+  overflow: hidden;
+}
+
+.table__scroll {
+  width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
 
 .table__layout {
   width: 100%;
   border-collapse: separate;
   border-spacing: 0;
-  background-color: $color-surface;
-  overflow: hidden;
-  // border: 1px solid $color-border-light;
-  // Header styling
-  .table__header-row {
-    background: $color-primary;
+  background: transparent;
+}
 
-    .table__header-cell {
-      @include font($font-size-2xl, $font-weight-medium, $line-height-normal);
-      color: $color-text-inverse;
-      text-align: left;
-      padding: $spacing-lg $spacing-md;
-      border: none;
-      position: relative;
+.table__header-row {
+  background: var(--mat-sys-surface-container);
+}
 
-      &::after {
-        content: '';
-        position: absolute;
-        right: 0;
-        top: 50%;
-        transform: translateY(-50%);
-        width: 1px;
-        height: 60%;
-        background-color: rgba($color-text-inverse, 0.2);
-      }
+.table__header-cell {
+  @include eyebrow-label(var(--mat-sys-on-surface-variant));
+  text-align: left;
+  padding: $spacing-md $spacing-lg;
+  border-bottom: 1px solid var(--mat-sys-outline-variant);
+  white-space: nowrap;
 
-      &:last-child::after {
-        display: none;
-      }
+  &:last-child {
+    text-align: right;
+  }
+}
 
-      // Responsive header styling
-      @include respond-to(md) {
-        @include font($font-size-2xl, $font-weight-medium, $line-height-normal);
-        padding: $spacing-xl $spacing-lg;
-      }
+.table__row {
+  transition: background-color 200ms ease;
 
-      @include respond-to(lg) {
-        text-align: center;
-        padding: $spacing-xl $spacing-xl;
-      }
-    }
+  &:hover {
+    background-color: var(--mat-sys-surface-container-low);
+  }
+}
+
+.table__cell {
+  @include type(body-md);
+  color: var(--mat-sys-on-surface);
+  padding: $spacing-md $spacing-lg;
+  border-bottom: 1px solid var(--mat-sys-outline-variant);
+  vertical-align: middle;
+
+  &:first-child {
+    font-weight: $font-weight-bold;
   }
 
-  // Data row styling
-  .table__row {
-    @include transition(background-color);
-    border-bottom: 1px solid $color-border-light!important;
-    
-    &:last-child {
-      border-bottom: none;
-    }
-
-    .table__cell {
-      &:first-child {
-        color: $color-primary;
-        font-weight: $font-weight-medium;
-        font-size: $font-size-2xl;
-      }
-
-      @include font($font-size-sm, $font-weight-regular, $line-height-normal);
-      padding: $spacing-2xl!important;
-      // border: none;
-      border-bottom: 1px solid $color-border-light!important;
-      vertical-align: middle;
-
-      // Responsive cell styling
-      @include respond-to(md) {
-        @include font($font-size-2xl, $font-weight-regular, $line-height-normal);
-        padding: $spacing-lg;
-      }
-
-      @include respond-to(lg) {
-        text-align: center;
-        padding: $spacing-lg $spacing-xl;
-      }
-    }
+  &:last-child {
+    text-align: right;
   }
 
-  // Empty state styling
-  &.table--empty {
-    .table__cell {
-      text-align: center;
-      padding: $spacing-3xl $spacing-md;
-      color: $color-text-disabled;
-      @include font($font-size-lg, $font-weight-regular, $line-height-relaxed);
+  a {
+    color: var(--mat-sys-secondary);
+    font-weight: $font-weight-medium;
+    text-decoration: none;
+    cursor: pointer;
+
+    &:hover {
+      text-decoration: underline;
+    }
+
+    &:focus-visible {
+      @include focus-ring(var(--mat-sys-secondary));
+      border-radius: $border-radius-sm;
     }
   }
+}
+
+.table__row:last-child .table__cell {
+  border-bottom: none;
+}
+
+.table__layout.table--empty .table__cell {
+  text-align: center;
+  padding: $spacing-3xl $spacing-md;
+  color: var(--mat-sys-on-surface-variant);
+  @include type(body-md);
 }
 
 .custom-menu {
-  margin: 0 auto;
-  background-color: $color-background;
-  border-radius: 50%;
-  padding: $spacing-sm;
-  width: 30px;
-  height: 30px;
-  display: flex;
-  justify-content: center;
+  @include flex-center;
+  margin-left: auto;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: $border-radius-full;
+  background: transparent;
+  color: var(--mat-sys-on-surface-variant);
   cursor: pointer;
-  align-items: center;
+  transition: background-color 200ms ease, color 200ms ease;
+
   &:hover {
-    background-color: $color-background-secondary;
+    background-color: var(--mat-sys-surface-container-high);
+    color: var(--mat-sys-on-surface);
+  }
+
+  &:focus-visible {
+    @include focus-ring(var(--mat-sys-secondary));
+  }
+
+  .material-symbols-outlined {
+    font-size: 1.25rem;
   }
 }
 
-// ============================================================================
-// PAGINATION STYLING
-// ============================================================================
-
-::ng-deep .mat-mdc-paginator {
-  background-color: $color-background-secondary;
-  border-top: 1px solid $color-border-light;
-  border-radius: 0 0 $border-radius-lg $border-radius-lg;
-  margin-top: 0;
-
-  .mat-mdc-paginator-container {
-    padding: $spacing-md $spacing-lg;
-    min-height: 56px;
-
-    @include respond-to(md) {
-      padding: $spacing-lg $spacing-xl;
-    }
+@include mobile-only {
+  .table__header-cell,
+  .table__cell {
+    padding: $spacing-sm $spacing-md;
   }
 
-  .mat-mdc-paginator-page-size,
-  .mat-mdc-paginator-range-label {
-    @include font($font-size-sm, $font-weight-regular, $line-height-normal);
-    color: $color-text-primary;
-
-    @include respond-to(md) {
-      @include font($font-size-base, $font-weight-regular, $line-height-normal);
-    }
+  .table__header-cell {
+    font-size: $type-label-xs-size;
   }
 
-  .mat-mdc-paginator-navigation-previous,
-  .mat-mdc-paginator-navigation-next {
-    .mat-mdc-icon-button {
-      @include button-base;
-      background-color: $color-button-primary;
-      color: $color-text-inverse;
-
-      &:hover:not([disabled]) {
-        background-color: $button-blue-600;
-        transform: translateY(-1px);
-      }
-
-      &[disabled] {
-        background-color: $color-border;
-        color: $color-text-disabled;
-      }
-    }
-  }
-
-  .mat-mdc-select {
-    .mat-mdc-select-trigger {
-      @include font($font-size-sm, $font-weight-regular, $line-height-normal);
-      color: $color-text-primary;
-
-      @include respond-to(md) {
-        @include font($font-size-base, $font-weight-regular, $line-height-normal);
-      }
-    }
-  }
-}
-
-// ============================================================================
-// RESPONSIVE ADJUSTMENTS
-// ============================================================================
-
-// Large screens and up
-@include respond-to(lg) {
-  .table__layout {
-    .table__header-row .table__header-cell {
-      position: relative;
-
-      &::before {
-        content: '';
-        position: absolute;
-        bottom: 0;
-        left: 50%;
-        transform: translateX(-50%);
-        width: 30%;
-        height: 2px;
-        background-color: $color-accent;
-        opacity: 0;
-        @include transition(opacity);
-      }
-
-      &:hover::before {
-        opacity: 1;
-      }
-    }
+  .table__cell {
+    @include type(body-sm);
   }
 }

--- a/src/app/shared/components/table/table.component.ts
+++ b/src/app/shared/components/table/table.component.ts
@@ -1,11 +1,13 @@
 import {
   Component,
+  ContentChild,
   EventEmitter,
   Input,
   OnChanges,
   OnInit,
   Output,
   SimpleChanges,
+  TemplateRef,
 } from '@angular/core';
 import { PageEvent } from '@angular/material/paginator';
 import { MatTableDataSource } from '@angular/material/table';
@@ -29,12 +31,17 @@ export class TableComponent implements OnInit, OnChanges {
   @Input() allowVisit: boolean = true;
   @Input() allowEdit: boolean = true;
   @Input() allowDelete: boolean = true;
+  @Input() showHeader: boolean = false;
+  @Input() showFooter: boolean = false;
+  @Input() boldColumns: string[] = [];
 
   @Output() pageChange: EventEmitter<PageEvent> = new EventEmitter<PageEvent>();
   @Output() visit: EventEmitter<TableDataSource> = new EventEmitter<TableDataSource>();
   @Output() edit: EventEmitter<TableDataSource> = new EventEmitter<TableDataSource>();
   @Output() delete: EventEmitter<TableDataSource> = new EventEmitter<TableDataSource>();
   @Output() linkClick: EventEmitter<TableDataSource> = new EventEmitter<TableDataSource>();
+
+  @ContentChild('actionTemplate', { static: false }) actionTemplate?: TemplateRef<unknown>;
 
   public customPageMetadata;
 

--- a/src/assets/styles/base/_prototype-utilities.scss
+++ b/src/assets/styles/base/_prototype-utilities.scss
@@ -309,6 +309,21 @@
 .text-status-info    { color: var(--md-status-info); }
 
 // ============================================================================
+// DIALOG CLOSE ICON — Material Symbols glyph used in mat-dialog headers
+// ============================================================================
+
+.dialog-close-icon {
+  font-size: 1.5rem;
+  cursor: pointer;
+  color: var(--mat-sys-on-surface-variant);
+  transition: color 200ms ease;
+
+  &:hover {
+    color: var(--md-status-error);
+  }
+}
+
+// ============================================================================
 // MISC
 // ============================================================================
 

--- a/src/assets/styles/sass-utils/_mixins.scss
+++ b/src/assets/styles/sass-utils/_mixins.scss
@@ -278,6 +278,88 @@
   transition: grid-template-rows $duration $timing;
 }
 
+@mixin form-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--mat-sys-surface-container-lowest);
+  border: 1px solid var(--mat-sys-outline-variant);
+  border-radius: $border-radius-md;
+  overflow: hidden;
+
+  thead tr {
+    background: var(--mat-sys-surface-container);
+  }
+
+  thead th {
+    @include eyebrow-label(var(--mat-sys-on-surface-variant));
+    padding: $spacing-md;
+    border: none;
+    position: relative;
+    text-align: left;
+
+    &::after {
+      content: '';
+      position: absolute;
+      right: 0;
+      top: 50%;
+      transform: translateY(-50%);
+      width: 1px;
+      height: 60%;
+      background-color: var(--mat-sys-outline-variant);
+    }
+
+    &:last-child::after { display: none; }
+  }
+
+  tbody tr.bg-error {
+    background: var(--md-status-error-container);
+  }
+
+  tbody td {
+    padding: $spacing-md;
+    text-align: center;
+    border: none;
+    position: relative;
+    vertical-align: middle;
+
+    &::after {
+      content: '';
+      position: absolute;
+      right: 0;
+      top: 50%;
+      transform: translateY(-50%);
+      width: 1px;
+      height: 60%;
+      background-color: var(--mat-sys-outline-variant);
+    }
+
+    &:last-child::after { display: none; }
+  }
+
+  .form-field input,
+  .form-field select {
+    border: none;
+    border-bottom: 1px solid var(--mat-sys-outline-variant);
+    outline: none;
+    background-color: transparent;
+    font-family: $font-family-body;
+    font-size: $type-body-md-size;
+    font-weight: $font-weight-regular;
+    line-height: $type-body-md-line;
+    padding: $spacing-xs 0;
+    transition: border-color 200ms ease;
+
+    &:focus {
+      border-bottom-color: var(--mat-sys-primary);
+    }
+  }
+
+  .form-field select {
+    cursor: pointer;
+    min-width: 7.5rem;
+  }
+}
+
 // ============================================================================
 // FLEXBOX MIXINS
 // ============================================================================


### PR DESCRIPTION
## Summary

Third step of the AGL redesign rollout. Reskins the data-heavy feature pages on top of the M3 foundation that lives on `feat/ui-redesign-foundation` (already shipped via PR #8 / PR #9). Public APIs on every shared component (`blogsphere-table`, `blogsphere-paginator`, `blogsphere-badge`) are preserved — only the SCSS chrome changes — so consumers keep working without template churn.

## Scope

**Shared atoms reskinned to M3**
- `blogsphere-table`: `:host` becomes the surface-container-lowest card, eyebrow-style header on surface-container, `outline-variant` dividers, first-cell bold + last-cell right-aligned, `.table__scroll` wrapper for mobile horizontal scroll, dead `::ng-deep .mat-mdc-paginator` block removed (now handled globally).
- `blogsphere-paginator`: pill toolbar on `surface-container-low`, `secondary-container` for the active page, `label-sm` typography, mobile size scaledown, focus-ring + touch-target preserved.
- `blogsphere-badge`: full M3 pill (uppercase `label-xs`, full-radius rounded-pill, `container` / `on-container` tone pairs); drops the `tint()` helper import.

**New shared atom**
- `blogsphere-method-pill` — reusable HTTP method indicator (GET / POST / PUT / DELETE / PATCH / HEAD / OPTIONS) backed by status + secondary + tertiary tokens, with `method` and optional `size` inputs.

**SCSS library additions**
- `form-table` mixin — the inline editable headers/transforms/destinations form-table chrome that route-setup and cluster-setup both used, with M3 tokens and focus-on-primary inputs.
- `.dialog-close-icon` utility — replaces three identical `.close-icon` blocks across the subscription dialogs.

**Feature pages reskinned**
- `api-routes` (route-list, route-details, route-setup) — route-details now uses `<blogsphere-method-pill>` instead of hand-rolled class bindings, and consolidates the duplicated `.rd-header-card` / `.rd-transform-card` blocks into a shared `.rd-row-card` base. Brings `route-details.component.scss` from 6.82 kB back **under** the 6 kB Angular SCSS budget.
- `api-cluster` (cluster-list, cluster-details, cluster-setup) — stats bento and audit cards on `md-card`, primary-fixed icon tints, destinations form-table now uses the shared mixin.
- `subscription` (list, api-product-details) — product hero on `md-card`, two-panel subscriptions layout switched to outline-variant + surface-container-lowest dividers, three create-dialog SCSS files deleted in favor of the new global `.dialog-close-icon` utility.

## What's NOT in this PR

- `user-profile` (still > 6 kB SCSS budget) and `user-manager` reskins — owned by PR 4.
- `success-page` + `maintenance-mode` — owned by PR 4.
- Final umbrella PR #8 (feat/ui-redesign-foundation → main) — refreshed and merged only after PR 4 is signed off.

## Test plan

- [ ] Production build: `ng build --configuration=production` (no new warnings; `route-details.component.scss` no longer flagged).
- [ ] Dev server compile: `ng serve` clean.
- [ ] Lints: clean across `src/app/shared/components/method-pill`, `src/app/features/api-routes`, `src/app/features/api-cluster`, `src/app/features/subscription`.
- [ ] Visual: api-route list table + paginator (active page = secondary-container, hover = surface-container-low) at 1440 + 375.
- [ ] Visual: api-route details — hero path-code pill, method pills, headers + transforms row cards, audit card.
- [ ] Visual: api-cluster list table + cluster-details stats grid.
- [ ] Visual: subscription list table + api-product-details two-panel layout + create dialogs (close icon hovers red).
- [ ] Smoke: filter / paginate / row action menu (Visit/Edit/Delete) / link click on a table row / delete dialog / snackbar.

## Branching

- Base: `feat/ui-redesign-foundation` (umbrella).
- Head: `feat/ui-redesign-phase3-heavy-features`.
- On approval: squash-or-merge into umbrella via `merge_pull_request` MCP, prune branch, then start PR 4.