### PR TITLE
feat(ui-redesign): phase 4 — user-manager, user-profile, success-page, maintenance-mode

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,12 +1,12 @@
 <main class="app-shell">
-  <blogsphere-navbar [isProfilePage]="isProfilePage"></blogsphere-navbar>
-
   <div class="app-shell__body">
     @if (!maintenanceMode && !isProfilePage) {
       <blogsphere-sidebar></blogsphere-sidebar>
     }
 
     <section class="app-shell__main" [class.app-shell__main--full]="isProfilePage">
+      <blogsphere-navbar [isProfilePage]="isProfilePage"></blogsphere-navbar>
+
       <div class="app-shell__content">
         @if (!isProfilePage) {
           <blogsphere-page-header></blogsphere-page-header>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -3,7 +3,7 @@
 
 .app-shell {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   height: 100vh;
   overflow: hidden;
   background: var(--md-background);
@@ -11,7 +11,9 @@
   &__body {
     flex: 1 1 auto;
     display: flex;
+    flex-direction: row;
     align-items: stretch;
+    min-width: 0;
     min-height: 0;
   }
 
@@ -21,8 +23,7 @@
     min-height: 0;
     display: flex;
     flex-direction: column;
-    overflow-y: auto;
-    overflow-x: hidden;
+    overflow: hidden;
 
     &--full {
       width: 100%;
@@ -31,6 +32,9 @@
 
   &__content {
     flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
     @include page-container;
     padding-block: $page-margin-mobile;
 

--- a/src/app/features/api-cluster/cluster-details/cluster-details.component.scss
+++ b/src/app/features/api-cluster/cluster-details/cluster-details.component.scss
@@ -4,13 +4,13 @@
 .cd {
   max-width: $container-max;
   margin: 0 auto;
-  padding: $spacing-xl $spacing-xl $spacing-3xl;
+  padding: $spacing-md $spacing-lg $spacing-2xl;
   @include flex-column;
-  gap: $spacing-xl;
+  gap: $spacing-md;
 
   @include mobile-only {
-    padding: $spacing-md $spacing-md $spacing-2xl;
-    gap: $spacing-lg;
+    padding: $spacing-sm $spacing-md $spacing-xl;
+    gap: $spacing-md;
   }
 }
 
@@ -23,7 +23,7 @@
 }
 
 .cd-stat {
-  @include md-card($padding: $spacing-lg $spacing-xl);
+  @include md-card($padding: $spacing-md $spacing-lg);
   @include flex-column;
   gap: $spacing-xs;
   border-left: 3px solid var(--mat-sys-secondary);

--- a/src/app/features/api-routes/route-details/route-details.component.scss
+++ b/src/app/features/api-routes/route-details/route-details.component.scss
@@ -4,12 +4,12 @@
 .rd {
   max-width: $container-max;
   margin: 0 auto;
-  padding: $spacing-lg $spacing-xl $spacing-2xl;
+  padding: $spacing-md $spacing-lg $spacing-xl;
   @include flex-column;
-  gap: $spacing-lg;
+  gap: $spacing-md;
 
   @include mobile-only {
-    padding: $spacing-md $spacing-md $spacing-2xl;
+    padding: $spacing-sm $spacing-md $spacing-lg;
   }
 }
 
@@ -124,7 +124,7 @@
   grid-template-columns: auto 1fr auto;
   align-items: center;
   gap: $spacing-md;
-  padding: $spacing-md $spacing-lg;
+  padding: $spacing-sm $spacing-md;
   border: 1px solid var(--mat-sys-outline-variant);
   border-radius: $border-radius-lg;
   background: var(--mat-sys-surface-container-lowest);

--- a/src/app/features/maintenance-mode/maintenance-mode.component.html
+++ b/src/app/features/maintenance-mode/maintenance-mode.component.html
@@ -1,50 +1,41 @@
-<div class="maintenance-page">
-  <div class="container">
-    <div class="row justify-content-center">
-      <div class="col-12 col-md-8 col-lg-6">
-        <div class="maintenance-page__content">
-          <!-- Animated Illustration -->
-          <div class="maintenance-page__illustration mb-2xl">
-            <img
-              src="assets/svgs/maintenance-illustration.svg"
-              alt="Maintenance in progress"
-              class="maintenance-page__illustration-img"
-            />
-          </div>
-
-          <!-- Title -->
-          <h1 class="maintenance-page__title text-center mb-lg">
-            We'll be back soon!
-          </h1>
-
-          <!-- Message -->
-          <div class="maintenance-page__message text-center mb-xl">
-            <p class="font-size-2xl">
-              Our team is performing scheduled maintenance to improve your
-              experience. We'll be back up and running shortly.
-            </p>
-          </div>
-
-          <!-- Helpful Tips -->
-          <div class="maintenance-page__tips mt-2xl">
-            <blogsphere-info-card
-              variant="tips"
-              size="large"
-              title="What's happening?"
-              icon="build"
-              [elevated]="false"
-              borderPosition="left"
-            >
-              <ul>
-                <li>We're upgrading our systems for better performance</li>
-                <li>Your data is safe and secure</li>
-                <li>Expected downtime is typically 15-30 minutes</li>
-                <li>Try refreshing in a few minutes if you need immediate access</li>
-              </ul>
-            </blogsphere-info-card>
-          </div>
-        </div>
-      </div>
+<section class="maintenance-page">
+  <article class="maintenance-page__card bg-surface-container-lowest border border-outline-variant rounded-xl elevation-low text-center">
+    <div class="maintenance-page__illustration">
+      <img
+        src="assets/svgs/maintenance-illustration.svg"
+        alt="Maintenance in progress"
+        class="maintenance-page__illustration-img"
+      />
     </div>
-  </div>
-</div>
+
+    <div class="maintenance-page__copy stack-md">
+      <h1 class="maintenance-page__title">We'll be back soon!</h1>
+      <p class="maintenance-page__message">
+        Our team is performing scheduled maintenance to improve your
+        experience. We'll be back up and running shortly.
+      </p>
+    </div>
+
+    <div class="maintenance-page__tips">
+      <blogsphere-info-card
+        variant="tips"
+        size="large"
+        title="What's happening?"
+        icon="build"
+        [elevated]="false"
+        borderPosition="left"
+      >
+        <ul>
+          <li>We're upgrading our systems for better performance</li>
+          <li>Your data is safe and secure</li>
+          <li>Expected downtime is typically 15-30 minutes</li>
+          <li>Try refreshing in a few minutes if you need immediate access</li>
+        </ul>
+      </blogsphere-info-card>
+    </div>
+
+    <p class="maintenance-page__footnote">
+      Need urgent assistance? Reach out to your administrator.
+    </p>
+  </article>
+</section>

--- a/src/app/features/maintenance-mode/maintenance-mode.component.scss
+++ b/src/app/features/maintenance-mode/maintenance-mode.component.scss
@@ -1,13 +1,37 @@
 @use 'sass-utils/variables' as *;
 @use 'sass-utils/mixins' as *;
 
+:host {
+  display: block;
+  min-height: 100%;
+}
+
 .maintenance-page {
   min-height: 100%;
   @include flex-center;
+  padding: $spacing-2xl $spacing-lg;
+  background:
+    radial-gradient(120% 80% at 50% 0%, var(--md-status-info-container) 0%, transparent 60%),
+    var(--mat-sys-surface);
 
-  &__content {
-    text-align: center;
-    max-width: 100%;
+  @include mobile-only {
+    padding: $spacing-lg $spacing-md;
+  }
+
+  &__card {
+    width: 100%;
+    max-width: 38rem;
+    padding: $spacing-2xl;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: $spacing-xl;
+
+    @include mobile-only {
+      padding: $spacing-xl $spacing-lg;
+      border-radius: $border-radius-lg;
+      gap: $spacing-lg;
+    }
   }
 
   &__illustration {
@@ -16,37 +40,46 @@
 
     &-img {
       width: 100%;
-      max-width: 320px;
+      max-width: 280px;
       height: auto;
+      animation: maintenance-float 3s ease-in-out infinite;
 
-      @include respond-to(xs) {
-        max-width: 260px;
+      @include mobile-only {
+        max-width: 220px;
       }
     }
   }
 
-  &__title {
-    @include heading(1);
-    color: $color-text-primary;
-    margin: 0;
+  &__copy {
+    width: 100%;
+  }
 
-    @include respond-to(md) {
-      font-size: $font-size-4xl;
+  &__title {
+    @include type(headline-lg);
+    color: var(--mat-sys-on-surface);
+
+    @include mobile-only {
+      @include type(headline-lg-mobile);
     }
   }
 
   &__message {
-    color: $color-text-secondary;
-    line-height: $line-height-relaxed;
-    max-width: 500px;
+    @include type(body-lg);
+    color: var(--mat-sys-on-surface-variant);
+    max-width: 32rem;
     margin: 0 auto;
   }
 
-}
+  &__tips {
+    width: 100%;
+    text-align: left;
+  }
 
-// Animation for illustration
-.maintenance-page__illustration-img {
-  animation: maintenance-float 3s ease-in-out infinite;
+  &__footnote {
+    @include type(label-sm);
+    color: var(--mat-sys-on-surface-variant);
+    margin: 0;
+  }
 }
 
 @keyframes maintenance-float {
@@ -56,5 +89,11 @@
   }
   50% {
     transform: translateY(-8px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .maintenance-page__illustration-img {
+    animation: none;
   }
 }

--- a/src/app/features/sidebar/sidebar.component.scss
+++ b/src/app/features/sidebar/sidebar.component.scss
@@ -5,6 +5,7 @@
   display: block;
   flex-shrink: 0;
   width: $sidebar-width;
+  height: 100vh;
   transition: width 0.25s ease-in-out;
 }
 
@@ -41,9 +42,9 @@
 
   @include mobile-only {
     position: fixed;
-    top: $topbar-height;
+    top: 0;
     left: 0;
-    height: calc(100% - #{$topbar-height});
+    height: 100%;
     width: $sidebar-width;
     z-index: $z-index-modal;
     transform: translateX(-100%);

--- a/src/app/features/sidebar/sidebar.component.scss
+++ b/src/app/features/sidebar/sidebar.component.scss
@@ -11,14 +11,6 @@
 
 :host(.host--collapsed) {
   width: $sidebar-collapsed-width;
-
-  &:hover {
-    width: $sidebar-width;
-
-    .sidenav {
-      width: $sidebar-width;
-    }
-  }
 }
 
 @include mobile-only {
@@ -80,14 +72,14 @@
   }
 
   &__logo {
-    width: 2rem;
-    height: 2rem;
+    width: 2.5rem;
+    height: 2.5rem;
     display: block;
     flex-shrink: 0;
   }
 
   &__brand-name {
-    @include type(headline-sm);
+    @include type(headline-lg);
     color: var(--md-on-surface);
     font-family: $font-family-heading;
     white-space: nowrap;
@@ -230,31 +222,6 @@
 
   .sidenav__signout {
     padding: $spacing-sm;
-  }
-
-  &:hover {
-    .sidenav__brand-name,
-    .sidenav__signout-label {
-      display: inline-block;
-    }
-
-    .sidenav__welcome-text {
-      display: flex;
-    }
-
-    .sidenav__header,
-    .sidenav__footer {
-      padding-left: $spacing-lg;
-      padding-right: $spacing-lg;
-    }
-
-    .sidenav__welcome {
-      justify-content: flex-start;
-    }
-
-    .sidenav__signout {
-      padding: $spacing-sm $spacing-md;
-    }
   }
 }
 

--- a/src/app/features/subscription/api-product-create-dialog/api-product-create-dialog.component.html
+++ b/src/app/features/subscription/api-product-create-dialog/api-product-create-dialog.component.html
@@ -1,58 +1,46 @@
-<div class="container pb-md">
-  <div
-    class="dialogue-header d-flex justify-content-between align-items-center border-bottom p-md"
-  >
-    <div>
-      <h1>Create API Product</h1>
-      <p class="font-size-xl">Create a new API product to manage your API endpoints.</p>
-    </div>
-    <div class="dialogue-actions">
-      <span
-        class="material-symbols-outlined dialog-close-icon"
-        (click)="closeDialog()"
-        >close</span
-      >
-    </div>
+<header class="dialog-header">
+  <div>
+    <h2 class="mat-mdc-dialog-title">Create API Product</h2>
+    <p class="dialog-subtitle">Create a new API product to manage your API endpoints.</p>
   </div>
-  <div class="dialogue-body pt-xl">
-    <form [formGroup]="apiProductFormGroup">
-      <div class="row">
-        <div class="col-12">
-          <mat-form-field class="w-75 font-size-xl">
-            <mat-label>Product name</mat-label>
-            <input matInput type="text" formControlName="productName" />
-            <mat-error>{{ getErrorMessage("productName") }}</mat-error>
-          </mat-form-field>
-        </div>
-      </div>
+  <blogsphere-icon-button
+    icon="close"
+    ariaLabel="Close dialog"
+    variant="ghost"
+    size="sm"
+    tone="on-surface"
+    (next)="closeDialog()"
+  ></blogsphere-icon-button>
+</header>
 
-      <div class="row">
-        <div class="col-12">
-          <mat-form-field class="w-75 font-size-xl">
-            <mat-label>Product description</mat-label>
-            <textarea
-              matInput
-              type="text"
-              rows="8"
-              formControlName="productDescription"
-            ></textarea>
-            <mat-error>{{ getErrorMessage("productDescription") }}</mat-error>
-          </mat-form-field>
-        </div>
-      </div>
+<div class="dialog-body stack-md">
+  <form [formGroup]="apiProductFormGroup" class="stack-md">
+    <mat-form-field class="w-100">
+      <mat-label>Product name</mat-label>
+      <input matInput type="text" formControlName="productName" />
+      <mat-error>{{ getErrorMessage("productName") }}</mat-error>
+    </mat-form-field>
 
-      <div class="row mt-md">
-        <div class="col-12">
-          <blogsphere-button
-            [isLoading]="isCreating$ | async"
-            [type]="ButtonType.primary"
-            [size]="ButtonSize.small"
-            (next)="onCreateApiProduct()"
-          >
-            Create
-          </blogsphere-button>
-        </div>
-      </div>
-    </form>
-  </div>
+    <mat-form-field class="w-100">
+      <mat-label>Product description</mat-label>
+      <textarea
+        matInput
+        type="text"
+        rows="8"
+        formControlName="productDescription"
+      ></textarea>
+      <mat-error>{{ getErrorMessage("productDescription") }}</mat-error>
+    </mat-form-field>
+  </form>
 </div>
+
+<footer class="dialog-actions">
+  <blogsphere-button
+    [isLoading]="isCreating$ | async"
+    [type]="ButtonType.primary"
+    [size]="ButtonSize.small"
+    (next)="onCreateApiProduct()"
+  >
+    Create
+  </blogsphere-button>
+</footer>

--- a/src/app/features/subscription/api-product-create-dialog/api-product-create-dialog.module.ts
+++ b/src/app/features/subscription/api-product-create-dialog/api-product-create-dialog.module.ts
@@ -4,10 +4,11 @@ import { ApiProductCreateDialogComponent } from './api-product-create-dialog.com
 import { AppMaterialModule } from 'src/app/app-material.module';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ButtonModule } from 'src/app/shared/components/button/button.module';
+import { IconButtonModule } from 'src/app/shared/components/icon-button/icon-button.module';
 
 @NgModule({
   declarations: [ApiProductCreateDialogComponent],
-  imports: [CommonModule, AppMaterialModule, ReactiveFormsModule, ButtonModule],
+  imports: [CommonModule, AppMaterialModule, ReactiveFormsModule, ButtonModule, IconButtonModule],
   exports: [ApiProductCreateDialogComponent],
 })
 export class ApiProductCreateDialogModule {}

--- a/src/app/features/subscription/api-product-details/api-product-details.component.scss
+++ b/src/app/features/subscription/api-product-details/api-product-details.component.scss
@@ -2,13 +2,13 @@
 @use 'sass-utils/mixins' as *;
 
 .product-details-box {
-  @include md-card($padding: $spacing-xl);
+  @include md-card($padding: $spacing-lg);
 
   .product-name {
     @include cluster($spacing-sm);
 
     h1 {
-      @include type(headline-md);
+      @include type(headline-sm);
       color: var(--mat-sys-on-surface);
     }
   }
@@ -35,12 +35,12 @@
 
 .api-subscriptions-layout {
   display: flex;
-  gap: $spacing-xl;
+  gap: $spacing-lg;
   min-height: 25rem;
 
   @include mobile-only {
     flex-direction: column;
-    gap: $spacing-lg;
+    gap: $spacing-md;
   }
 }
 

--- a/src/app/features/subscription/subscribed-api-create-dialog/subscribed-api-create-dialog.component.html
+++ b/src/app/features/subscription/subscribed-api-create-dialog/subscribed-api-create-dialog.component.html
@@ -1,56 +1,47 @@
-<div class="container pb-md">
-  <div class="dialogue-header d-flex justify-content-between align-items-center border-bottom p-md">
-    <div>
-      <h1>Add Subscribed API</h1>
-      <p class="font-size-xl">Add a new API to the product.</p>
-    </div>
-    <div class="dialogue-actions">
-      <span class="material-symbols-outlined dialog-close-icon" (click)="closeDialog()">close</span>
-    </div>
+<header class="dialog-header">
+  <div>
+    <h2 class="mat-mdc-dialog-title">Add Subscribed API</h2>
+    <p class="dialog-subtitle">Add a new API to the product.</p>
   </div>
-  <div class="dialogue-body pt-xl">
-    <form [formGroup]="subscribedApiFormGroup">
-      <div class="row">
-        <div class="col-12">
-          <mat-form-field class="w-75 font-size-xl">
-            <mat-label>API name</mat-label>
-            <input matInput type="text" formControlName="apiName" />
-            <mat-error>{{ getErrorMessage('apiName') }}</mat-error>
-          </mat-form-field>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col-12">
-          <mat-form-field class="w-75 font-size-xl">
-            <mat-label>API path</mat-label>
-            <input matInput type="text" formControlName="apiPath" />
-            <mat-error>{{ getErrorMessage('apiPath') }}</mat-error>
-          </mat-form-field>
-        </div>
-      </div>
+  <blogsphere-icon-button
+    icon="close"
+    ariaLabel="Close dialog"
+    variant="ghost"
+    size="sm"
+    tone="on-surface"
+    (next)="closeDialog()"
+  ></blogsphere-icon-button>
+</header>
 
-      <div class="row">
-        <div class="col-12">
-          <mat-form-field class="w-75 font-size-xl">
-            <mat-label>API description</mat-label>
-            <textarea matInput type="text" rows="8" formControlName="apiDescription"></textarea>
-            <mat-error>{{ getErrorMessage('apiDescription') }}</mat-error>
-          </mat-form-field>
-        </div>
-      </div>
+<div class="dialog-body stack-md">
+  <form [formGroup]="subscribedApiFormGroup" class="stack-md">
+    <mat-form-field class="w-100">
+      <mat-label>API name</mat-label>
+      <input matInput type="text" formControlName="apiName" />
+      <mat-error>{{ getErrorMessage('apiName') }}</mat-error>
+    </mat-form-field>
 
-      <div class="row mt-md">
-        <div class="col-12">
-          <blogsphere-button
-            [isLoading]="isCreating$ | async"
-            [type]="ButtonType.primary"
-            [size]="ButtonSize.small"
-            (next)="onCreateSubscribedApi()"
-          >
-            Create
-          </blogsphere-button>
-        </div>
-      </div>
-    </form>
-  </div>
+    <mat-form-field class="w-100">
+      <mat-label>API path</mat-label>
+      <input matInput type="text" formControlName="apiPath" />
+      <mat-error>{{ getErrorMessage('apiPath') }}</mat-error>
+    </mat-form-field>
+
+    <mat-form-field class="w-100">
+      <mat-label>API description</mat-label>
+      <textarea matInput type="text" rows="8" formControlName="apiDescription"></textarea>
+      <mat-error>{{ getErrorMessage('apiDescription') }}</mat-error>
+    </mat-form-field>
+  </form>
 </div>
+
+<footer class="dialog-actions">
+  <blogsphere-button
+    [isLoading]="isCreating$ | async"
+    [type]="ButtonType.primary"
+    [size]="ButtonSize.small"
+    (next)="onCreateSubscribedApi()"
+  >
+    Create
+  </blogsphere-button>
+</footer>

--- a/src/app/features/subscription/subscribed-api-create-dialog/subscribed-api-create-dialog.module.ts
+++ b/src/app/features/subscription/subscribed-api-create-dialog/subscribed-api-create-dialog.module.ts
@@ -4,10 +4,11 @@ import { SubscribedApiCreateDialogComponent } from './subscribed-api-create-dial
 import { AppMaterialModule } from 'src/app/app-material.module';
 import { ButtonModule } from 'src/app/shared/components/button/button.module';
 import { ReactiveFormsModule } from '@angular/forms';
+import { IconButtonModule } from 'src/app/shared/components/icon-button/icon-button.module';
 
 @NgModule({
   declarations: [SubscribedApiCreateDialogComponent],
-  imports: [CommonModule, AppMaterialModule, ButtonModule, ReactiveFormsModule],
+  imports: [CommonModule, AppMaterialModule, ButtonModule, ReactiveFormsModule, IconButtonModule],
   exports: [SubscribedApiCreateDialogComponent],
 })
 export class SubscribedApiCreateDialogModule {}

--- a/src/app/features/subscription/subscription-create-dialog/subscription-create-dialog.component.html
+++ b/src/app/features/subscription/subscription-create-dialog/subscription-create-dialog.component.html
@@ -1,37 +1,38 @@
-<div class="container pb-md">
-  <div class="dialogue-header d-flex justify-content-between align-items-center border-bottom p-md">
-    <div>
-      <h1>Create Subscription</h1>
-      <p class="font-size-xl">Create a new subscription for the API product</p>
-    </div>
-    <div class="dialogue-actions">
-      <span class="material-symbols-outlined dialog-close-icon" (click)="closeDialog()">close</span>
-    </div>
+<header class="dialog-header">
+  <div>
+    <h2 class="mat-mdc-dialog-title">Create Subscription</h2>
+    <p class="dialog-subtitle">Create a new subscription for the API product.</p>
   </div>
-  <div class="dialogue-body pt-xl">
-    <form [formGroup]="subscriptionFormGroup">
-      <div class="row">
-        <div class="col-12">
-          <mat-form-field class="w-75 font-size-xl">
-            <mat-label>Subscription name</mat-label>
-            <input matInput type="text" formControlName="subscriptionName" />
-          </mat-form-field>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col-12">
-          <mat-form-field class="w-75 font-size-xl">
-            <mat-label>Subscription description</mat-label>
-            <textarea matInput type="text" rows="8" formControlName="subscriptionDescription"></textarea>
-          </mat-form-field>
-        </div>
-      </div>
+  <blogsphere-icon-button
+    icon="close"
+    ariaLabel="Close dialog"
+    variant="ghost"
+    size="sm"
+    tone="on-surface"
+    (next)="closeDialog()"
+  ></blogsphere-icon-button>
+</header>
 
-      <div class="row mt-md">
-        <div class="col-12">
-          <blogsphere-button [type]="ButtonType.primary" [size]="ButtonSize.small" (next)="onCreateSubscription()">Create</blogsphere-button>
-        </div>
-      </div>
-    </form>
-  </div>
+<div class="dialog-body stack-md">
+  <form [formGroup]="subscriptionFormGroup" class="stack-md">
+    <mat-form-field class="w-100">
+      <mat-label>Subscription name</mat-label>
+      <input matInput type="text" formControlName="subscriptionName" />
+    </mat-form-field>
+
+    <mat-form-field class="w-100">
+      <mat-label>Subscription description</mat-label>
+      <textarea matInput type="text" rows="8" formControlName="subscriptionDescription"></textarea>
+    </mat-form-field>
+  </form>
 </div>
+
+<footer class="dialog-actions">
+  <blogsphere-button
+    [type]="ButtonType.primary"
+    [size]="ButtonSize.small"
+    (next)="onCreateSubscription()"
+  >
+    Create
+  </blogsphere-button>
+</footer>

--- a/src/app/features/subscription/subscription-create-dialog/subscription-create-dialog.module.ts
+++ b/src/app/features/subscription/subscription-create-dialog/subscription-create-dialog.module.ts
@@ -4,10 +4,11 @@ import { SubscriptionCreateDialogComponent } from './subscription-create-dialog.
 import { AppMaterialModule } from 'src/app/app-material.module';
 import { ButtonModule } from 'src/app/shared/components/button/button.module';
 import { ReactiveFormsModule } from '@angular/forms';
+import { IconButtonModule } from 'src/app/shared/components/icon-button/icon-button.module';
 
 @NgModule({
   declarations: [SubscriptionCreateDialogComponent],
-  imports: [CommonModule, AppMaterialModule, ButtonModule, ReactiveFormsModule],
+  imports: [CommonModule, AppMaterialModule, ButtonModule, ReactiveFormsModule, IconButtonModule],
   exports: [SubscriptionCreateDialogComponent],
 })
 export class SubscriptionCreateDialogModule {}

--- a/src/app/features/success-page/success-page.component.html
+++ b/src/app/features/success-page/success-page.component.html
@@ -1,30 +1,33 @@
 @if (requestPageState$ | async; as requestPageState) {
-  <div class="success-page__layout">
-    <div class="success-page__layout-content">
-      <div class="success-page__layout-content--image">
-        <img src="../../../assets/images/check.png" class="img-fluid" alt="" />
+  <section class="success-page">
+    <article class="success-page__card bg-surface-container-lowest border border-outline-variant rounded-xl elevation-low text-center">
+      <div class="success-page__glyph">
+        <span class="material-symbols-rounded success-page__glyph-icon">check_circle</span>
       </div>
-      <div class="success-page__layout-content--heading">{{ requestPageState.heading }}</div>
-      <div class="success-page__layout-content--subheading">{{ requestPageState.subHeading }}</div>
-    </div>
-    <div class="success-page__layout-action">
-      <!-- button components here -->
-      @if (requestPageState.previousUrl) {
+
+      <div class="success-page__copy stack-sm">
+        <h1 class="success-page__heading">{{ requestPageState.heading }}</h1>
+        <p class="success-page__subheading">{{ requestPageState.subHeading }}</p>
+      </div>
+
+      <div class="success-page__actions">
+        @if (requestPageState.previousUrl) {
+          <blogsphere-button
+            [type]="ButtonType.primary"
+            [size]="ButtonSize.medium"
+            (next)="previousClick(requestPageState.previousUrl)"
+            >
+            Back
+          </blogsphere-button>
+        }
         <blogsphere-button
-          [type]="ButtonType.primary"
+          [type]="ButtonType.secondary"
           [size]="ButtonSize.medium"
-          (next)="previousClick(requestPageState.previousUrl)"
+          (next)="nextClick(requestPageState.nextUrl)"
           >
-          Back
+          {{ requestPageState.nextButtonLabel }}
         </blogsphere-button>
-      }
-      <blogsphere-button
-        [type]="ButtonType.secondary"
-        [size]="ButtonSize.medium"
-        (next)="nextClick(requestPageState.nextUrl)"
-        >
-        {{ requestPageState.nextButtonLabel }}
-      </blogsphere-button>
-    </div>
-  </div>
+      </div>
+    </article>
+  </section>
 }

--- a/src/app/features/success-page/success-page.component.scss
+++ b/src/app/features/success-page/success-page.component.scss
@@ -1,38 +1,80 @@
 @use 'sass-utils/variables' as *;
 @use 'sass-utils/mixins' as *;
 
-.success-page__layout {
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  gap: $spacing-2xl;
-  padding: $spacing-2xl;
-  &-content {
+:host {
+  display: block;
+  min-height: 100%;
+}
+
+.success-page {
+  min-height: 100%;
+  @include flex-center;
+  padding: $spacing-2xl $spacing-lg;
+  background:
+    radial-gradient(120% 80% at 50% 0%, var(--md-status-success-container) 0%, transparent 60%),
+    var(--mat-sys-surface);
+
+  @include mobile-only {
+    padding: $spacing-lg $spacing-md;
+  }
+
+  &__card {
+    width: 100%;
+    max-width: 32rem;
+    padding: $spacing-2xl;
     display: flex;
     flex-direction: column;
     align-items: center;
-    justify-content: center;
-    gap: $spacing-md;
-    &--image{
-      img{
-        height: 65px;
-        width: 65px;
-      }
-    }
-    &--heading{
-      @include font($font-size-4xl, $font-weight-bold, $line-height-tight);
-    }
-    &--subheading{
-      @include font($font-size-2xl, $font-weight-regular, $line-height-normal);
+    gap: $spacing-lg;
+
+    @include mobile-only {
+      padding: $spacing-xl $spacing-lg;
+      border-radius: $border-radius-lg;
     }
   }
-  &-action{
+
+  &__glyph {
+    @include flex-center;
+    width: 5rem;
+    height: 5rem;
+    border-radius: $border-radius-full;
+    background: var(--md-status-success-container);
+    color: var(--md-status-success);
+    box-shadow: 0 0 0 10px rgba($success-100, 0.4);
+
+    &-icon {
+      font-size: 2.75rem;
+      line-height: 1;
+      font-variation-settings: 'FILL' 1, 'wght' 500, 'GRAD' 0, 'opsz' 48;
+    }
+  }
+
+  &__copy {
+    width: 100%;
+  }
+
+  &__heading {
+    @include type(headline-lg);
+    color: var(--mat-sys-on-surface);
+
+    @include mobile-only {
+      @include type(headline-lg-mobile);
+    }
+  }
+
+  &__subheading {
+    @include type(body-lg);
+    color: var(--mat-sys-on-surface-variant);
+    max-width: 28rem;
+    margin: 0 auto;
+  }
+
+  &__actions {
     display: flex;
-    flex-direction: row;
+    flex-wrap: wrap;
     align-items: center;
     justify-content: center;
     gap: $spacing-md;
+    width: 100%;
   }
 }

--- a/src/app/features/success-page/success-page.component.scss
+++ b/src/app/features/success-page/success-page.component.scss
@@ -7,8 +7,10 @@
 }
 
 .success-page {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   min-height: 100%;
-  @include flex-center;
   padding: $spacing-2xl $spacing-lg;
   background:
     radial-gradient(120% 80% at 50% 0%, var(--md-status-success-container) 0%, transparent 60%),
@@ -21,11 +23,11 @@
   &__card {
     width: 100%;
     max-width: 32rem;
-    padding: $spacing-2xl;
+    padding: $spacing-2xl $spacing-xl;
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: $spacing-lg;
+    gap: $spacing-md;
 
     @include mobile-only {
       padding: $spacing-xl $spacing-lg;
@@ -37,6 +39,7 @@
     @include flex-center;
     width: 5rem;
     height: 5rem;
+    margin: 0 auto;
     border-radius: $border-radius-full;
     background: var(--md-status-success-container);
     color: var(--md-status-success);
@@ -54,12 +57,8 @@
   }
 
   &__heading {
-    @include type(headline-lg);
+    @include type(headline-md);
     color: var(--mat-sys-on-surface);
-
-    @include mobile-only {
-      @include type(headline-lg-mobile);
-    }
   }
 
   &__subheading {

--- a/src/app/features/user-manager/app-user/app-user.component.html
+++ b/src/app/features/user-manager/app-user/app-user.component.html
@@ -1,1 +1,6 @@
-<p>app-user works!</p>
+<div @fadeSlideInOut class="d-flex p-lg">
+  <blogsphere-empty-state
+    icon="group"
+    text="App users will be displayed here once the integration is wired up."
+  ></blogsphere-empty-state>
+</div>

--- a/src/app/features/user-manager/app-user/app-user.module.ts
+++ b/src/app/features/user-manager/app-user/app-user.module.ts
@@ -1,10 +1,11 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { AppUserComponent } from './app-user.component';
+import { EmptyStateModule } from 'src/app/shared/components/empty-state/empty-state.module';
 
 @NgModule({
   declarations: [AppUserComponent],
-  imports: [CommonModule],
+  imports: [CommonModule, EmptyStateModule],
   exports: [AppUserComponent],
 })
 export class AppUserModule {}

--- a/src/app/features/user-manager/management-user/management-user-details/management-user-details.component.scss
+++ b/src/app/features/user-manager/management-user/management-user-details/management-user-details.component.scss
@@ -5,21 +5,19 @@
 // PAGE SHELL
 // ============================================================================
 .ud {
-  max-width: 1280px;
+  max-width: $container-max;
   margin: 0 auto;
   padding: $spacing-lg $spacing-xl $spacing-2xl;
   @include flex-column;
   gap: $spacing-lg;
 
-  @include respond-to(xs) {
+  @include mobile-only {
     padding: $spacing-md $spacing-md $spacing-2xl;
     gap: $spacing-lg;
   }
 }
 
-.ud-grid-row {
-  margin-bottom: 0;
-}
+.ud-grid-row { margin-bottom: 0; }
 
 // ============================================================================
 // HERO BODY (slotted into blogsphere-page-hero) — user-specific identity
@@ -27,138 +25,118 @@
 // ============================================================================
 .ud-hero-body {
   &__title {
-    display: flex;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: $spacing-xs $spacing-sm;
-    @include font($font-size-lg, $font-weight-medium);
-    color: rgba($color-text-primary, 0.65);
+    @include cluster($spacing-sm);
+    row-gap: $spacing-xs;
     margin: 0 0 $spacing-md;
+    font-size: $type-body-lg-size;
+    font-weight: $font-weight-medium;
+    color: var(--mat-sys-on-surface-variant);
 
-    @include respond-to(xs) {
-      justify-content: center;
-    }
+    @include mobile-only { justify-content: center; }
   }
 
   &__title-icon {
-    font-size: 18px;
+    font-size: 1.125rem;
     line-height: 1;
-    color: $color-primary;
+    color: var(--mat-sys-on-surface-variant);
+    flex-shrink: 0;
   }
 
-  &__title-text {
-    line-height: 1.2;
-  }
+  &__title-text { line-height: 1.2; }
 
   &__title-sep {
-    color: rgba($color-text-primary, 0.3);
+    color: var(--mat-sys-outline);
     margin: 0 $spacing-xs;
   }
 
   &__chips {
-    display: flex;
-    flex-wrap: wrap;
-    gap: $spacing-sm;
+    @include cluster($spacing-sm);
 
-    @include respond-to(xs) {
-      justify-content: center;
-    }
+    @include mobile-only { justify-content: center; }
   }
 }
 
 .ud-hero-btn-icon {
-  font-size: 18px;
+  font-size: 1.125rem;
   line-height: 1;
 }
 
 .ud-hero-contact-item {
-  display: inline-flex;
-  align-items: center;
-  gap: $spacing-xs;
-  @include font($font-size-sm, $font-weight-regular);
-  color: rgba($color-text-primary, 0.7);
+  @include cluster($spacing-xs);
+  font-size: $type-body-sm-size;
+  color: var(--mat-sys-on-surface-variant);
   min-width: 0;
 
   &__icon {
-    font-size: 18px;
+    font-size: 1.125rem;
     line-height: 1;
-    color: $color-primary;
+    color: var(--mat-sys-on-surface-variant);
+    flex-shrink: 0;
   }
 
   &__text {
     @include text-truncate;
-    max-width: 260px;
-    @include transition(color);
+    max-width: 16.25rem;
+    transition: color 200ms ease;
   }
 
   &:hover &__text {
-    color: $color-primary;
+    color: var(--mat-sys-on-surface);
   }
 }
 
-:host ::ng-deep .ud-card-grid {
-  blogsphere-details-card {
-    display: block;
-    height: 100%;
-
-    .details-card {
-      height: 100%;
-      display: flex;
-      flex-direction: column;
-    }
-
-    .details-card__body {
-      flex: 1;
-    }
-  }
+// Equal-height stretch helpers — these reach into shared component
+// templates that live outside this file's scope, so ::ng-deep is required.
+:host ::ng-deep .ud-card-grid blogsphere-details-card,
+:host ::ng-deep .ud-panel-grid blogsphere-section-panel {
+  display: block;
+  height: 100%;
 }
 
-:host ::ng-deep .ud-panel-grid {
-  blogsphere-section-panel {
-    display: block;
-    height: 100%;
-
-    .section-panel {
-      height: 100%;
-      display: flex;
-      flex-direction: column;
-    }
-
-    .section-panel__body {
-      flex: 1;
-    }
-  }
+:host ::ng-deep .ud-card-grid .details-card,
+:host ::ng-deep .ud-panel-grid .section-panel {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
+:host ::ng-deep .ud-card-grid .details-card__body,
+:host ::ng-deep .ud-panel-grid .section-panel__body {
+  flex: 1;
+}
+
+// ============================================================================
+// ROLE CARD — one per assigned role inside the Roles section panel
+// ============================================================================
 .ud-role-card {
   display: flex;
   align-items: flex-start;
   gap: $spacing-md;
   padding: $spacing-md $spacing-lg;
-  border: 1px solid $color-border-light;
+  border: 1px solid var(--mat-sys-outline-variant);
   border-radius: $border-radius-lg;
-  background: $color-background;
+  background: var(--mat-sys-surface-container-lowest);
   cursor: default;
-  @include transition(all);
+  transition: border-color 200ms ease, box-shadow 200ms ease, transform 200ms ease;
 
   &:hover {
-    border-color: rgba($color-primary, 0.3);
-    box-shadow: 0 4px 12px $color-shadow-light;
+    border-color: var(--mat-sys-secondary);
+    box-shadow: var(--md-elevation-card);
     transform: translateY(-1px);
   }
 
   &__icon {
-    width: 40px;
-    height: 40px;
-    border-radius: $border-radius-md;
-    background: rgba($color-primary, 0.08);
     @include flex-center;
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: $border-radius-md;
+    background: var(--mat-sys-secondary-container);
     flex-shrink: 0;
 
     .material-symbols-rounded {
-      font-size: 22px;
+      font-size: 1.375rem;
       line-height: 1;
-      color: $color-primary;
+      color: var(--mat-sys-on-secondary-container);
     }
   }
 
@@ -167,23 +145,19 @@
     min-width: 0;
   }
 
-  &__head {
-    display: flex;
-    align-items: center;
-    gap: $spacing-sm;
-    flex-wrap: wrap;
-  }
+  &__head { @include cluster($spacing-sm); }
 
   &__name {
-    @include font($font-size-lg, $font-weight-medium);
-    color: $color-text-primary;
+    font-size: $type-body-lg-size;
+    font-weight: $font-weight-medium;
+    color: var(--mat-sys-on-surface);
     margin: 0;
     line-height: 1.3;
   }
 
   &__desc {
-    @include font($font-size-sm, $font-weight-regular);
-    color: rgba($color-text-primary, 0.6);
+    font-size: $type-body-sm-size;
+    color: var(--mat-sys-on-surface-variant);
     margin: $spacing-xs 0 0;
     line-height: $line-height-normal;
   }
@@ -200,45 +174,43 @@
 .ud-perm-group {
   &:not(:last-child) {
     padding-bottom: $spacing-md;
-    border-bottom: 1px dashed $color-border-light;
+    border-bottom: 1px dashed var(--mat-sys-outline-variant);
   }
 
   &__head {
-    display: flex;
-    align-items: center;
-    gap: $spacing-sm;
+    @include cluster($spacing-sm);
     margin-bottom: $spacing-lg;
   }
 
   &__head-icon {
-    font-size: 20px;
+    font-size: 1.25rem;
     line-height: 1;
-    color: $color-primary;
+    color: var(--mat-sys-on-surface-variant);
     font-variation-settings:
       'FILL' 1,
       'wght' 400;
   }
 
   &__head-name {
-    @include font($font-size-lg, $font-weight-medium);
-    color: $color-text-primary;
+    font-size: $type-body-lg-size;
+    font-weight: $font-weight-medium;
+    color: var(--mat-sys-on-surface);
     text-transform: capitalize;
     letter-spacing: 0.2px;
   }
 
   &__head-count {
-    @include font($font-size-base, $font-weight-bold);
-    color: rgba($color-text-primary, 0.5);
+    font-size: $type-label-xs-size;
+    font-weight: $type-label-xs-weight;
+    letter-spacing: $type-label-xs-tracking;
+    color: var(--mat-sys-on-surface-variant);
     text-transform: uppercase;
-    letter-spacing: 0.6px;
     margin-left: $spacing-xs;
   }
 }
 
 .ud-perm-chips {
-  display: flex;
-  flex-wrap: wrap;
-  gap: $spacing-sm;
+  @include cluster($spacing-sm);
 }
 
 .ud-perm-chip {
@@ -248,64 +220,52 @@
   max-width: 100%;
   padding: 6px $spacing-md;
   border-radius: $border-radius-full;
-  border: 1px solid rgba($color-primary, 0.15);
-  background: rgba($color-primary, 0.04);
-  @include font($font-size-lg, $font-weight-medium);
-  color: rgba($color-text-primary, 0.85);
+  border: 1px solid var(--mat-sys-outline-variant);
+  background: var(--mat-sys-surface-container-low);
+  font-size: $type-body-sm-size;
+  font-weight: $font-weight-medium;
+  color: var(--mat-sys-on-surface);
   letter-spacing: 0.015em;
   cursor: default;
-  @include transition(all);
+  transition: background-color 200ms ease, border-color 200ms ease, color 200ms ease;
 
   &:hover {
-    background: rgba($color-primary, 0.1);
-    border-color: rgba($color-primary, 0.3);
-    color: $color-primary;
+    background: var(--mat-sys-secondary-container);
+    border-color: var(--mat-sys-secondary);
+    color: var(--mat-sys-on-secondary-container);
   }
 
   &__icon {
-    font-size: 14px;
+    font-size: 0.875rem;
     line-height: 1;
-    color: $color-primary;
+    color: var(--mat-sys-on-surface-variant);
     flex-shrink: 0;
   }
 
   &__text {
     @include text-truncate;
-    max-width: 280px;
+    max-width: 17.5rem;
   }
 }
 
 // ============================================================================
-// AUTHOR (Activity creators)
+// RAW JSON VIEW
 // ============================================================================
-.ud-author {
-  display: inline-flex;
-  align-items: center;
-  gap: $spacing-sm;
-  cursor: pointer;
+.details-json {
+  padding: $spacing-md;
 
-  &__avatar {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 28px;
-    height: 28px;
-    border-radius: $border-radius-full;
-    background: $color-primary;
-    color: $color-text-inverse;
-    @include font($font-size-xs, $font-weight-bold);
-    text-transform: uppercase;
-    flex-shrink: 0;
-  }
-
-  &__name {
-    @include font($font-size-base, $font-weight-medium);
-    color: $color-text-primary;
-    @include text-truncate;
-
-    &--muted {
-      color: rgba($color-text-primary, 0.4);
-      font-weight: $font-weight-regular;
-    }
+  &__pre {
+    margin: 0;
+    font-family: $font-family-mono;
+    font-size: $type-body-sm-size;
+    line-height: $type-body-sm-line;
+    color: var(--mat-sys-on-surface);
+    background: var(--mat-sys-surface-container-low);
+    border: 1px solid var(--mat-sys-outline-variant);
+    border-radius: $border-radius-md;
+    padding: $spacing-md;
+    overflow-x: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
   }
 }

--- a/src/app/features/user-manager/management-user/management-user.component.html
+++ b/src/app/features/user-manager/management-user/management-user.component.html
@@ -1,4 +1,4 @@
-<div @fadeSlideInOut>
+<div @fadeSlideInOut class="management-user-list">
   @if (!(isManagementUsersLoading$ | async) && !(isManagementUsersCountLoading$ | async)) {
     @if (!(isMobileView$ | async)) {
       <div class="row">
@@ -10,6 +10,7 @@
               [paginationMetadata]="managementUsersPageMetadata$ | async"
               [dataLength]="totalManagementUsers$ | async"
               [columnMap]="columnNameMap"
+              [boldColumns]="boldColumns"
               [actionEnabled]="true"
               [allowEdit]="canWriteManagementUsers$ | async"
               [allowDelete]="canWriteManagementUsers$ | async"
@@ -21,6 +22,7 @@
               [title]="'No Management Users'"
               [subtitle]="'There are no management users to display.'"
               [buttonLabel]="'Add Management User'"
+              [iconType]="'empty'"
             ></blogsphere-no-content-layout>
           }
         </div>
@@ -28,9 +30,10 @@
     }
   }
 
-  <div class="w-100 h-auto d-flex justify-content-center">
+  <div class="w-100 d-flex justify-content-center">
     @if ((isManagementUsersLoading$ | async) || (isManagementUsersCountLoading$ | async)) {
       <mat-progress-spinner mode="indeterminate" diameter="50" color="primary"></mat-progress-spinner>
     }
   </div>
 </div>
+

--- a/src/app/features/user-manager/management-user/management-user.component.ts
+++ b/src/app/features/user-manager/management-user/management-user.component.ts
@@ -47,6 +47,7 @@ export class ManagementUserComponent implements OnInit, OnDestroy {
   public managementUsersDataSource = new MatTableDataSource<ManagementUserSummary>([]);
   public showEmptyStateButton: boolean;
   public displayedColumns: string[] = ['employeeId', 'email', 'fullName', 'roles', 'department', 'status'];
+  public boldColumns: string[] = ['fullName'];
   public columnNameMap: TableColumnMap = {
     employeeId: { value: 'employeeId', isLinkField: true },
     email: { value: 'email' },

--- a/src/app/features/user-manager/user-manager.component.html
+++ b/src/app/features/user-manager/user-manager.component.html
@@ -1,11 +1,13 @@
-<div class="user-manager__container">
-  <blogsphere-search-layout *ngIf="!isUserDetailsRoute" [allowAdd]="canWriteUsers$ | async" addButtonLabel="Create User" filterLabel="Filter Users" [isFileterFormValid]="true">
-    <ng-container>
-      a form here
-    </ng-container>
+<div class="user-manager-container position-relative">
+  <blogsphere-search-layout
+    *ngIf="!isUserDetailsRoute"
+    [allowAdd]="canWriteUsers$ | async"
+    addButtonLabel="Create User"
+    filterLabel="Filter Users"
+    [isFileterFormValid]="true"
+  >
+    <ng-container></ng-container>
   </blogsphere-search-layout>
-  <ng-container>
-      <router-outlet></router-outlet>
-  </ng-container>
+
+  <router-outlet></router-outlet>
 </div>
-  

--- a/src/app/features/user-profile/user-profile-action-row/user-profile-action-row.component.html
+++ b/src/app/features/user-profile/user-profile-action-row/user-profile-action-row.component.html
@@ -1,0 +1,22 @@
+<button
+  type="button"
+  class="action-row"
+  (click)="onActivate($event)"
+  [attr.aria-label]="label + ' — ' + actionLabel"
+>
+  <span class="action-row__tile" aria-hidden="true">
+    <span class="material-symbols-rounded">{{ icon }}</span>
+  </span>
+
+  <span class="action-row__body">
+    <span class="action-row__label">{{ label }}</span>
+    @if (hint) {
+      <span class="action-row__hint">{{ hint }}</span>
+    }
+  </span>
+
+  <span class="action-row__cta">
+    <span>{{ actionLabel }}</span>
+    <span class="material-symbols-rounded" aria-hidden="true">chevron_right</span>
+  </span>
+</button>

--- a/src/app/features/user-profile/user-profile-action-row/user-profile-action-row.component.scss
+++ b/src/app/features/user-profile/user-profile-action-row/user-profile-action-row.component.scss
@@ -1,0 +1,101 @@
+@use 'sass-utils/variables' as *;
+@use 'sass-utils/mixins' as *;
+
+:host {
+  display: block;
+}
+
+.action-row {
+  display: flex;
+  align-items: center;
+  gap: $spacing-md;
+  width: 100%;
+  padding: $spacing-lg $spacing-xl;
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid var(--mat-sys-outline-variant);
+  text-align: inherit;
+  cursor: pointer;
+  color: inherit;
+  transition: background-color 200ms ease;
+
+  &:hover,
+  &:focus-visible {
+    background: var(--mat-sys-surface-container-low);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--mat-sys-primary);
+    outline-offset: -2px;
+  }
+
+  :host:last-of-type & {
+    border-bottom: 0;
+  }
+
+  @include respond-to(xs) {
+    flex-wrap: wrap;
+    padding: $spacing-md;
+    gap: $spacing-sm;
+  }
+}
+
+.action-row__tile {
+  width: 2.5rem;
+  height: 2.5rem;
+  flex-shrink: 0;
+  border-radius: $border-radius-xl;
+  background: var(--mat-sys-secondary-container);
+  color: var(--mat-sys-on-secondary-container);
+  @include flex-center;
+
+  .material-symbols-rounded {
+    font-size: 1.375rem;
+    font-variation-settings: 'FILL' 1, 'wght' 400;
+  }
+}
+
+.action-row__body {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.action-row__label {
+  @include type(body-md);
+  font-weight: $font-weight-medium;
+  color: var(--mat-sys-on-surface);
+}
+
+.action-row__hint {
+  @include type(body-sm);
+  color: var(--mat-sys-on-surface-variant);
+}
+
+.action-row__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+  padding: $spacing-xs $spacing-md;
+  border-radius: $border-radius-full;
+  border: 1px solid var(--mat-sys-outline);
+  color: var(--mat-sys-primary);
+  @include type(label-sm);
+  font-weight: $font-weight-medium;
+  white-space: nowrap;
+  transition: background-color 200ms ease, border-color 200ms ease;
+
+  .material-symbols-rounded {
+    font-size: 1.125rem;
+  }
+
+  .action-row:hover &,
+  .action-row:focus-visible & {
+    background: var(--mat-sys-primary-container);
+    border-color: var(--mat-sys-primary);
+    color: var(--mat-sys-on-primary-container);
+  }
+}

--- a/src/app/features/user-profile/user-profile-action-row/user-profile-action-row.component.spec.ts
+++ b/src/app/features/user-profile/user-profile-action-row/user-profile-action-row.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { UserProfileActionRowComponent } from './user-profile-action-row.component';
+import { UserProfileActionRowModule } from './user-profile-action-row.module';
+
+describe('UserProfileActionRowComponent', () => {
+  let component: UserProfileActionRowComponent;
+  let fixture: ComponentFixture<UserProfileActionRowComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({ imports: [UserProfileActionRowModule] }).compileComponents();
+    fixture = TestBed.createComponent(UserProfileActionRowComponent);
+    component = fixture.componentInstance;
+    component.icon = 'lock_reset';
+    component.label = 'Change password';
+    component.hint = 'Create a new password for your account';
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/user-profile/user-profile-action-row/user-profile-action-row.component.ts
+++ b/src/app/features/user-profile/user-profile-action-row/user-profile-action-row.component.ts
@@ -1,0 +1,22 @@
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+
+@Component({
+  selector: 'blogsphere-user-profile-action-row',
+  templateUrl: './user-profile-action-row.component.html',
+  styleUrls: ['./user-profile-action-row.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: false,
+})
+export class UserProfileActionRowComponent {
+  @Input() icon: string = '';
+  @Input() label: string = '';
+  @Input() hint: string = '';
+  @Input() actionLabel: string = 'Manage';
+
+  @Output() next = new EventEmitter<void>();
+
+  onActivate(event: Event): void {
+    event.preventDefault();
+    this.next.emit();
+  }
+}

--- a/src/app/features/user-profile/user-profile-action-row/user-profile-action-row.module.ts
+++ b/src/app/features/user-profile/user-profile-action-row/user-profile-action-row.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { UserProfileActionRowComponent } from './user-profile-action-row.component';
+
+@NgModule({
+  declarations: [UserProfileActionRowComponent],
+  imports: [CommonModule],
+  exports: [UserProfileActionRowComponent],
+})
+export class UserProfileActionRowModule {}

--- a/src/app/features/user-profile/user-profile.component.html
+++ b/src/app/features/user-profile/user-profile.component.html
@@ -1,196 +1,130 @@
 <div class="account-center">
   @if (profileViewModel$ | async; as vm) {
     @if (!vm.isLoading) {
-      <!-- Breadcrumb navigation -->
-      <nav class="account-center__breadcrumb">
-        <a routerLink="/dashboard" class="account-center__breadcrumb-link">
-          <span class="material-symbols-outlined">home</span>
+      <nav class="account-center__crumbs" aria-label="Breadcrumb">
+        <a routerLink="/dashboard" class="account-center__crumb-link">
+          <span class="material-symbols-rounded">home</span>
           <span>Home</span>
         </a>
-        <span class="material-symbols-outlined account-center__breadcrumb-sep">chevron_right</span>
-        <span class="account-center__breadcrumb-current">Account Center</span>
+        <span class="material-symbols-rounded account-center__crumb-sep" aria-hidden="true">chevron_right</span>
+        <span class="account-center__crumb-current">Account Center</span>
       </nav>
-      <!-- Page title -->
-      <div class="account-center__heading">
+
+      <header class="account-center__heading">
         <h1 class="account-center__title">Account Center</h1>
         <p class="account-center__subtitle">
           Manage your profile details, security settings and account preferences across Blogsphere.
         </p>
-      </div>
-      <!-- Profile identity card -->
-      <section class="account-center__profile-card">
-        <div class="account-center__profile-top">
-          <div class="account-center__avatar">
-            <span class="account-center__avatar-initials">{{ vm.initials }}</span>
-          </div>
-          <div class="account-center__profile-info">
-            <h2 class="account-center__profile-name">{{ vm.user?.fullName || 'User' }}</h2>
-            <p class="account-center__profile-email">{{ vm.user?.email || 'No email available' }}</p>
-            @if (vm.role) {
-              <span class="account-center__profile-badge">
-                <span class="material-symbols-outlined">verified</span>
-                {{ vm.role }}
+      </header>
+
+      <blogsphere-page-hero
+        [title]="vm.user?.fullName || 'User'"
+        [subtitle]="vm.user?.email || 'No email available'"
+        [compact]="true"
+      >
+        <blogsphere-page-hero-avatar
+          hero-avatar
+          shape="circle"
+          [initials]="vm.initials"
+        ></blogsphere-page-hero-avatar>
+
+        @if (vm.role) {
+          <div hero-body class="account-center__hero-meta">
+            <blogsphere-status-pill
+              tone="info"
+              icon="verified"
+              [label]="vm.role"
+              size="sm"
+            ></blogsphere-status-pill>
+            @if (vm.user?.department) {
+              <span class="account-center__hero-dept">
+                <span class="material-symbols-rounded" aria-hidden="true">business</span>
+                <span>{{ vm.user.department }}</span>
               </span>
             }
           </div>
-        </div>
-        @if (vm.user?.department) {
-          <div class="account-center__profile-meta">
-            <span class="material-symbols-outlined">business</span>
-            <span>{{ vm.user.department }}</span>
-          </div>
         }
-      </section>
-      <!-- Personal information section -->
+      </blogsphere-page-hero>
+
       <section class="account-center__section">
         <div class="account-center__section-header">
-          <h3 class="account-center__section-title">Personal information</h3>
+          <h2 class="account-center__section-title">Personal information</h2>
           <p class="account-center__section-desc">
             Your personal details used across the Blogsphere workspace.
           </p>
         </div>
-        <div class="account-center__card">
-          <div class="account-center__row">
-            <div class="account-center__row-icon">
-              <span class="material-symbols-outlined">badge</span>
-            </div>
-            <div class="account-center__row-content">
-              <span class="account-center__row-label">Full name</span>
-              <span class="account-center__row-value">{{ vm.user?.fullName || 'Not set' }}</span>
-            </div>
-          </div>
-          <div class="account-center__row">
-            <div class="account-center__row-icon">
-              <span class="material-symbols-outlined">mail</span>
-            </div>
-            <div class="account-center__row-content">
-              <span class="account-center__row-label">Email address</span>
-              <span class="account-center__row-value account-center__row-value--mono">
-                {{ vm.user?.email || 'Not set' }}
-              </span>
-            </div>
-          </div>
-          <div class="account-center__row">
-            <div class="account-center__row-icon">
-              <span class="material-symbols-outlined">apartment</span>
-            </div>
-            <div class="account-center__row-content">
-              <span class="account-center__row-label">Department</span>
-              <span class="account-center__row-value">{{ vm.user?.department || 'Not set' }}</span>
-            </div>
-          </div>
-          <div class="account-center__row account-center__row--last">
-            <div class="account-center__row-icon">
-              <span class="material-symbols-outlined">fingerprint</span>
-            </div>
-            <div class="account-center__row-content">
-              <span class="account-center__row-label">Employee ID</span>
-              <span class="account-center__row-value account-center__row-value--mono">
-                {{ vm.user?.employeeId || 'Not set' }}
-              </span>
-            </div>
-          </div>
-        </div>
+        <blogsphere-details-card mode="keyValue" icon="badge" title="Personal information">
+          <blogsphere-kv-row label="Full name">{{ vm.user?.fullName || 'Not set' }}</blogsphere-kv-row>
+          <blogsphere-kv-row label="Email address" variant="mono">{{ vm.user?.email || 'Not set' }}</blogsphere-kv-row>
+          <blogsphere-kv-row label="Department">{{ vm.user?.department || 'Not set' }}</blogsphere-kv-row>
+          <blogsphere-kv-row label="Employee ID" variant="mono">{{ vm.user?.employeeId || 'Not set' }}</blogsphere-kv-row>
+        </blogsphere-details-card>
       </section>
-      <!-- Password & Security section -->
+
       <section class="account-center__section">
         <div class="account-center__section-header">
-          <h3 class="account-center__section-title">Password & security</h3>
+          <h2 class="account-center__section-title">Password &amp; security</h2>
           <p class="account-center__section-desc">
             Manage your sign-in protection and account recovery options.
           </p>
         </div>
-        <div class="account-center__card">
-          <div class="account-center__row account-center__row--interactive" (click)="resetPassword()">
-            <div class="account-center__row-icon">
-              <span class="material-symbols-outlined">lock_reset</span>
-            </div>
-            <div class="account-center__row-content">
-              <span class="account-center__row-label">Change password</span>
-              <span class="account-center__row-hint">Create a new password for your account</span>
-            </div>
-            <button class="account-center__row-action" type="button">
-              <span>Manage</span>
-              <span class="material-symbols-outlined">chevron_right</span>
-            </button>
-          </div>
-          <div class="account-center__row account-center__row--interactive" (click)="redirectToIdentityServer()">
-            <div class="account-center__row-icon">
-              <span class="material-symbols-outlined">security</span>
-            </div>
-            <div class="account-center__row-content">
-              <span class="account-center__row-label">Two-factor authentication</span>
-              <span class="account-center__row-hint">Add an extra layer of protection when signing in</span>
-            </div>
-            <button class="account-center__row-action" type="button">
-              <span>Manage</span>
-              <span class="material-symbols-outlined">chevron_right</span>
-            </button>
-          </div>
-          <div class="account-center__row account-center__row--interactive account-center__row--last" (click)="redirectToIdentityServer()">
-            <div class="account-center__row-icon">
-              <span class="material-symbols-outlined">phone_iphone</span>
-            </div>
-            <div class="account-center__row-content">
-              <span class="account-center__row-label">Recovery phone</span>
-              <span class="account-center__row-hint">Add or update your phone number for account recovery</span>
-            </div>
-            <button class="account-center__row-action" type="button">
-              <span>Manage</span>
-              <span class="material-symbols-outlined">chevron_right</span>
-            </button>
-          </div>
-        </div>
+        <blogsphere-details-card mode="keyValue" icon="encrypted" title="Password & security" [flushBody]="true">
+          <blogsphere-user-profile-action-row
+            icon="lock_reset"
+            label="Change password"
+            hint="Create a new password for your account"
+            (next)="resetPassword()"
+          ></blogsphere-user-profile-action-row>
+          <blogsphere-user-profile-action-row
+            icon="security"
+            label="Two-factor authentication"
+            hint="Add an extra layer of protection when signing in"
+            (next)="redirectToIdentityServer()"
+          ></blogsphere-user-profile-action-row>
+          <blogsphere-user-profile-action-row
+            icon="phone_iphone"
+            label="Recovery phone"
+            hint="Add or update your phone number for account recovery"
+            (next)="redirectToIdentityServer()"
+          ></blogsphere-user-profile-action-row>
+        </blogsphere-details-card>
       </section>
-      <!-- Access & Permissions section -->
+
       <section class="account-center__section">
         <div class="account-center__section-header">
-          <h3 class="account-center__section-title">Access & permissions</h3>
+          <h2 class="account-center__section-title">Access &amp; permissions</h2>
           <p class="account-center__section-desc">
             Your role and permission scope within the Blogsphere platform.
           </p>
         </div>
-        <div class="account-center__card">
-          <div class="account-center__row">
-            <div class="account-center__row-icon">
-              <span class="material-symbols-outlined">admin_panel_settings</span>
-            </div>
-            <div class="account-center__row-content">
-              <span class="account-center__row-label">Role</span>
-              <span class="account-center__row-value">{{ vm.role || 'Not assigned' }}</span>
-            </div>
-          </div>
-          <div class="account-center__row account-center__row--last">
-            <div class="account-center__row-icon">
-              <span class="material-symbols-outlined">key</span>
-            </div>
-            <div class="account-center__row-content">
-              <span class="account-center__row-label">Permissions</span>
-              @if (vm.permissions.length) {
-                <div class="account-center__permissions">
-                  @for (permission of vm.permissions; track permission) {
-                    <span class="account-center__permission-chip">
-                      {{ permission }}
-                    </span>
-                  }
-                </div>
-              } @else {
-                <span class="account-center__row-hint">No permissions assigned</span>
-              }
-            </div>
-          </div>
-        </div>
+        <blogsphere-details-card mode="keyValue" icon="admin_panel_settings" title="Access & permissions">
+          <blogsphere-kv-row label="Role">{{ vm.role || 'Not assigned' }}</blogsphere-kv-row>
+          <blogsphere-kv-row label="Permissions">
+            @if (vm.permissions.length) {
+              <div class="account-center__perms">
+                @for (permission of vm.permissions; track permission) {
+                  <span class="account-center__perm-chip">{{ permission }}</span>
+                }
+              </div>
+            } @else {
+              <span class="account-center__perms-empty">No permissions assigned</span>
+            }
+          </blogsphere-kv-row>
+        </blogsphere-details-card>
       </section>
-      <!-- Footer note -->
-      <footer class="account-center__footer">
-        <span class="material-symbols-outlined account-center__footer-icon">shield</span>
-        <span>Your account is protected by Blogsphere. To update sensitive details like your email or password, you will be securely redirected to your identity provider.</span>
-      </footer>
+
+      <blogsphere-info-card
+        variant="info"
+        icon="shield"
+        borderPosition="left"
+        [elevated]="false"
+      >
+        Your account is protected by Blogsphere. To update sensitive details like your email or password, you will be securely redirected to your identity provider.
+      </blogsphere-info-card>
     } @else {
       <div class="account-center__loading">
         <blogsphere-loader [enabled]="true"></blogsphere-loader>
       </div>
     }
   }
-
 </div>

--- a/src/app/features/user-profile/user-profile.component.scss
+++ b/src/app/features/user-profile/user-profile.component.scss
@@ -1,416 +1,145 @@
 @use 'sass-utils/variables' as *;
 @use 'sass-utils/mixins' as *;
 
+:host {
+  display: block;
+}
+
 .account-center {
-  max-width: 780px;
+  max-width: 880px;
   margin: 0 auto;
-  padding: $spacing-xl $spacing-md $spacing-3xl;
+  padding: $spacing-xl $spacing-xl $spacing-3xl;
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-xl;
   min-height: 100%;
-
-  // ── Breadcrumb ──────────────────────────────────────────────────────
-  &__breadcrumb {
-    display: flex;
-    align-items: center;
-    gap: $spacing-xs;
-    margin-bottom: $spacing-xl;
-  }
-
-  &__breadcrumb-link {
-    @include font($font-size-2xl, $font-weight-medium);
-    color: $color-primary;
-    text-decoration: none;
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    transition: color 0.2s ease;
-
-    .material-symbols-outlined {
-      font-size: 22px;
-    }
-
-    &:hover {
-      color: $color-primary-dark;
-    }
-  }
-
-  &__breadcrumb-sep {
-    font-size: 22px;
-    color: $gray-400;
-  }
-
-  &__breadcrumb-current {
-    @include font($font-size-2xl, $font-weight-medium);
-    color: rgba($color-text-primary, 0.55);
-  }
-
-  // ── Page heading ────────────────────────────────────────────────────
-  &__heading {
-    margin-bottom: $spacing-xl;
-  }
-
-  &__title {
-    @include font($font-size-5xl, $font-weight-bold, $line-height-tight);
-    color: $color-text-primary;
-    margin: 0 0 $spacing-sm 0;
-    letter-spacing: -0.3px;
-  }
-
-  &__subtitle {
-    @include font($font-size-2xl, $font-weight-regular);
-    color: rgba($color-text-primary, 0.6);
-    margin: 0;
-    max-width: 600px;
-  }
-
-  // ── Profile identity card ──────────────────────────────────────────
-  &__profile-card {
-    @include card;
-    padding: $spacing-xl;
-    margin-bottom: $spacing-2xl;
-    border: 1px solid $color-border-light;
-  }
-
-  &__profile-top {
-    display: flex;
-    align-items: center;
-    gap: $spacing-lg;
-  }
-
-  &__avatar {
-    width: 96px;
-    height: 96px;
-    border-radius: $border-radius-full;
-    background: $gradient-primary;
-    @include flex-center;
-    flex-shrink: 0;
-    box-shadow: 0 4px 12px rgba($primary-500, 0.25);
-  }
-
-  &__avatar-initials {
-    @include font($font-size-4xl, $font-weight-bold);
-    color: $white;
-    letter-spacing: 1px;
-    line-height: 1;
-    user-select: none;
-  }
-
-  &__profile-info {
-    min-width: 0;
-    flex: 1;
-  }
-
-  &__profile-name {
-    @include font($font-size-4xl, $font-weight-bold, $line-height-tight);
-    color: $color-text-primary;
-    margin: 0 0 4px 0;
-  }
-
-  &__profile-email {
-    @include font($font-size-2xl, $font-weight-regular);
-    color: rgba($color-text-primary, 0.65);
-    margin: 0 0 $spacing-sm 0;
-    font-family: $font-family-secondary;
-    @include text-truncate;
-  }
-
-  &__profile-badge {
-    @include font($font-size-lg, $font-weight-medium);
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    color: $color-primary;
-    background: rgba($color-primary, 0.08);
-    border: 1px solid rgba($color-primary, 0.15);
-    padding: 4px $spacing-md;
-    border-radius: $border-radius-full;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-
-    .material-symbols-outlined {
-      font-size: 18px;
-      font-variation-settings: 'FILL' 1;
-    }
-  }
-
-  &__profile-meta {
-    display: flex;
-    align-items: center;
-    gap: $spacing-sm;
-    margin-top: $spacing-lg;
-    padding-top: $spacing-lg;
-    border-top: 1px solid $color-border-light;
-    @include font($font-size-2xl, $font-weight-medium);
-    color: rgba($color-text-primary, 0.6);
-
-    .material-symbols-outlined {
-      font-size: 24px;
-      color: $gray-500;
-    }
-  }
-
-  // ── Section layout ─────────────────────────────────────────────────
-  &__section {
-    margin-bottom: $spacing-2xl;
-  }
-
-  &__section-header {
-    margin-bottom: $spacing-md;
-  }
-
-  &__section-title {
-    @include font($font-size-4xl, $font-weight-bold, $line-height-tight);
-    color: $color-text-primary;
-    margin: 0 0 $spacing-xs 0;
-  }
-
-  &__section-desc {
-    @include font($font-size-2xl, $font-weight-regular);
-    color: rgba($color-text-primary, 0.55);
-    margin: 0;
-  }
-
-  // ── Card & row system ──────────────────────────────────────────────
-  &__card {
-    @include card;
-    border: 1px solid $color-border-light;
-    overflow: hidden;
-  }
-
-  &__row {
-    display: flex;
-    align-items: center;
-    gap: $spacing-md;
-    padding: $spacing-lg $spacing-xl;
-    border-bottom: 1px solid $color-border-light;
-    transition: background-color 0.15s ease;
-
-    &--last {
-      border-bottom: none;
-    }
-
-    &--interactive {
-      cursor: pointer;
-
-      &:hover {
-        background: rgba($color-primary, 0.03);
-      }
-    }
-  }
-
-  &__row-icon {
-    width: 48px;
-    height: 48px;
-    border-radius: $border-radius-xl;
-    background: rgba($color-primary, 0.07);
-    @include flex-center;
-    flex-shrink: 0;
-
-    .material-symbols-outlined {
-      font-size: 24px;
-      color: $color-primary;
-    }
-  }
-
-  &__row-content {
-    flex: 1;
-    min-width: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 3px;
-  }
-
-  &__row-label {
-    @include font($font-size-2xl, $font-weight-medium);
-    color: $color-text-primary;
-  }
-
-  &__row-value {
-    @include font($font-size-2xl, $font-weight-regular);
-    color: rgba($color-text-primary, 0.75);
-    @include text-truncate;
-
-    &--mono {
-      font-family: $font-family-secondary;
-      font-size: $font-size-2xl;
-      color: rgba($color-text-primary, 0.7);
-      background: rgba($color-primary, 0.04);
-      padding: 2px $spacing-sm;
-      border-radius: $border-radius-base;
-      display: inline-block;
-      max-width: 100%;
-      @include text-truncate;
-    }
-  }
-
-  &__row-hint {
-    @include font($font-size-xl, $font-weight-regular);
-    color: rgba($color-text-primary, 0.5);
-  }
-
-  &__row-action {
-    @include font($font-size-lg, $font-weight-medium);
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    color: $color-primary;
-    background: transparent;
-    border: 1px solid rgba($color-primary, 0.2);
-    border-radius: $border-radius-full;
-    padding: $spacing-sm $spacing-lg;
-    cursor: pointer;
-    white-space: nowrap;
-    flex-shrink: 0;
-    transition: all 0.2s ease;
-
-    .material-symbols-outlined {
-      font-size: 20px;
-    }
-
-    &:hover {
-      background: rgba($color-primary, 0.06);
-      border-color: rgba($color-primary, 0.35);
-    }
-  }
-
-  // ── Permissions ────────────────────────────────────────────────────
-  &__permissions {
-    display: flex;
-    flex-wrap: wrap;
-    gap: $spacing-sm;
-    margin-top: 4px;
-  }
-
-  &__permission-chip {
-    @include font($font-size-lg, $font-weight-medium);
-    color: rgba($color-text-primary, 0.7);
-    background: rgba($color-primary, 0.06);
-    border: 1px solid rgba($color-primary, 0.12);
-    padding: 4px $spacing-md;
-    border-radius: $border-radius-full;
-    letter-spacing: 0.2px;
-    text-transform: lowercase;
-  }
-
-  // ── Footer note ────────────────────────────────────────────────────
-  &__footer {
-    display: flex;
-    align-items: center;
-    gap: $spacing-md;
-    padding: $spacing-lg $spacing-xl;
-    background: rgba($color-primary, 0.03);
-    border: 1px solid rgba($color-primary, 0.08);
-    border-radius: $border-radius-lg;
-    @include font($font-size-xl, $font-weight-regular);
-    color: rgba($color-text-primary, 0.6);
-    line-height: $line-height-relaxed;
-  }
-
-  &__footer-icon {
-    font-size: 24px;
-    color: $color-primary;
-    flex-shrink: 0;
-  }
-
-  // ── Loading state ──────────────────────────────────────────────────
-  &__loading {
-    position: relative;
-    min-height: 320px;
-    border-radius: $border-radius-lg;
-    overflow: hidden;
-  }
-
-  // ── Responsive ─────────────────────────────────────────────────────
-  @include respond-to(md) {
-    &__title {
-      font-size: $font-size-4xl;
-    }
-
-    &__profile-name {
-      font-size: $font-size-3xl;
-    }
-
-    &__avatar {
-      width: 80px;
-      height: 80px;
-    }
-
-    &__avatar-initials {
-      font-size: $font-size-3xl;
-    }
-  }
 
   @include respond-to(xs) {
     padding: $spacing-md $spacing-md $spacing-xl;
+    gap: $spacing-lg;
+  }
 
-    &__title {
-      font-size: $font-size-3xl;
+  &__crumbs {
+    display: flex;
+    align-items: center;
+    gap: $spacing-xs;
+    @include type(label-sm);
+    color: var(--mat-sys-on-surface-variant);
+  }
+
+  &__crumb-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    color: var(--mat-sys-primary);
+    text-decoration: none;
+    transition: color 200ms ease;
+
+    .material-symbols-rounded {
+      font-size: 1.125rem;
     }
 
-    &__subtitle {
-      font-size: $font-size-xl;
+    &:hover {
+      color: var(--mat-sys-on-primary-container);
     }
+  }
 
-    &__profile-card {
-      padding: $spacing-lg;
+  &__crumb-sep {
+    font-size: 1.125rem;
+    color: var(--mat-sys-outline);
+  }
+
+  &__crumb-current {
+    color: var(--mat-sys-on-surface-variant);
+  }
+
+  &__heading {
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-xs;
+  }
+
+  &__title {
+    @include type(headline-md);
+    color: var(--mat-sys-on-surface);
+  }
+
+  &__subtitle {
+    @include type(body-md);
+    color: var(--mat-sys-on-surface-variant);
+    max-width: 60ch;
+  }
+
+  &__hero-meta {
+    display: flex;
+    align-items: center;
+    gap: $spacing-md;
+    flex-wrap: wrap;
+    margin-top: $spacing-xs;
+  }
+
+  &__hero-dept {
+    display: inline-flex;
+    align-items: center;
+    gap: $spacing-xs;
+    @include type(body-sm);
+    color: var(--mat-sys-on-surface-variant);
+
+    .material-symbols-rounded {
+      font-size: 1.125rem;
+      color: var(--mat-sys-secondary);
     }
+  }
 
-    &__profile-top {
-      flex-direction: column;
-      align-items: flex-start;
-      gap: $spacing-md;
-    }
+  &__section {
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-md;
+  }
 
-    &__avatar {
-      width: 72px;
-      height: 72px;
-    }
+  &__section-header {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
 
-    &__avatar-initials {
-      font-size: $font-size-2xl;
-    }
+  &__section-title {
+    @include type(headline-sm);
+    color: var(--mat-sys-on-surface);
+  }
 
-    &__profile-name {
-      font-size: $font-size-2xl;
-    }
+  &__section-desc {
+    @include type(body-sm);
+    color: var(--mat-sys-on-surface-variant);
+  }
 
-    &__profile-email {
-      font-size: $font-size-xl;
-    }
+  &__perms {
+    display: flex;
+    flex-wrap: wrap;
+    gap: $spacing-xs;
+  }
 
-    &__row {
-      padding: $spacing-md;
-      gap: $spacing-sm;
-      flex-wrap: wrap;
-    }
+  &__perm-chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px $spacing-sm;
+    border-radius: $border-radius-full;
+    background: var(--mat-sys-secondary-container);
+    color: var(--mat-sys-on-secondary-container);
+    @include type(label-sm);
+    text-transform: lowercase;
+    letter-spacing: 0.2px;
+  }
 
-    &__row-icon {
-      width: 40px;
-      height: 40px;
+  &__perms-empty {
+    @include type(body-sm);
+    color: var(--mat-sys-on-surface-variant);
+  }
 
-      .material-symbols-outlined {
-        font-size: 20px;
-      }
-    }
-
-    &__row-label {
-      font-size: $font-size-xl;
-    }
-
-    &__row-value {
-      font-size: $font-size-xl;
-    }
-
-    &__row-hint {
-      font-size: $font-size-lg;
-    }
-
-    &__section-title {
-      font-size: $font-size-3xl;
-    }
-
-    &__footer {
-      padding: $spacing-md;
-      font-size: $font-size-lg;
-    }
+  &__loading {
+    position: relative;
+    min-height: 20rem;
+    border-radius: $border-radius-lg;
+    overflow: hidden;
   }
 }

--- a/src/app/features/user-profile/user-profile.module.ts
+++ b/src/app/features/user-profile/user-profile.module.ts
@@ -1,9 +1,16 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { UserProfileComponent } from './user-profile.component';
 import { RouterModule } from '@angular/router';
+
 import { LoaderModule } from 'src/app/shared/components/loader/loader.module';
+import { PageHeroModule } from 'src/app/shared/components/page-hero/page-hero.module';
+import { DetailsCardModule } from 'src/app/shared/components/details-card/details-card.module';
+import { StatusPillModule } from 'src/app/shared/components/status-pill/status-pill.module';
+import { InfoCardModule } from 'src/app/shared/components/info-card/info-card.module';
+
+import { UserProfileComponent } from './user-profile.component';
 import { UserProfileRoutingModule } from './user-profile-routing.module';
+import { UserProfileActionRowModule } from './user-profile-action-row/user-profile-action-row.module';
 
 @NgModule({
   declarations: [UserProfileComponent],
@@ -11,6 +18,11 @@ import { UserProfileRoutingModule } from './user-profile-routing.module';
     CommonModule,
     RouterModule,
     LoaderModule,
+    PageHeroModule,
+    DetailsCardModule,
+    StatusPillModule,
+    InfoCardModule,
+    UserProfileActionRowModule,
     UserProfileRoutingModule,
   ],
 })

--- a/src/app/shared/components/details-card/details-card.component.scss
+++ b/src/app/shared/components/details-card/details-card.component.scss
@@ -9,9 +9,13 @@
     display: flex;
     align-items: center;
     gap: $spacing-md;
-    padding: $spacing-lg $spacing-xl;
-    border-bottom: 1px solid $color-border-light;
-    background: $color-background-secondary;
+    padding: $spacing-md $spacing-lg;
+    border-bottom: 1px solid var(--mat-sys-outline-variant);
+    background: var(--mat-sys-surface-container-low);
+
+    @include mobile-only {
+      padding: $spacing-sm $spacing-md;
+    }
   }
 
   &__header-icon {
@@ -20,8 +24,8 @@
     justify-content: center;
     line-height: 1;
     flex-shrink: 0;
-    color: $color-primary;
-    font-size: 22px;
+    color: var(--mat-sys-secondary);
+    font-size: 1.25rem;
     font-variation-settings:
       'FILL' 1,
       'wght' 400,
@@ -30,19 +34,18 @@
   }
 
   &__header-title {
-    @include font($font-size-2xl, $font-weight-medium);
-    color: $color-text-primary;
-    margin: 0 !important;
+    @include type(headline-sm);
+    color: var(--mat-sys-on-surface);
+    margin: 0;
     display: flex;
     align-items: center;
     gap: $spacing-sm;
-    line-height: 1.2 !important;
     align-self: center;
   }
 
   &__header-count {
-    @include font($font-size-base, $font-weight-medium);
-    color: $color-primary;
+    @include type(label-sm);
+    color: var(--mat-sys-secondary);
     background: rgba($color-primary, 0.08);
     border-radius: $border-radius-full;
     padding: 2px $spacing-sm;
@@ -50,7 +53,11 @@
   }
 
   &__body {
-    padding: $spacing-xl;
+    padding: $spacing-lg;
+
+    @include mobile-only {
+      padding: $spacing-md;
+    }
 
     &--flush {
       padding: 0;

--- a/src/app/shared/components/details-card/kv-row/kv-row.component.scss
+++ b/src/app/shared/components/details-card/kv-row/kv-row.component.scss
@@ -6,8 +6,8 @@
   grid-template-columns: 180px 1fr;
   align-items: center;
   gap: $spacing-lg;
-  padding: $spacing-md 0;
-  border-bottom: 1px solid rgba($color-border, 0.3);
+  padding: $spacing-sm 0;
+  border-bottom: 1px solid var(--mat-sys-outline-variant);
 
   &:last-child {
     border-bottom: none;
@@ -20,13 +20,14 @@
 }
 
 .details-kv__key {
-  @include font($font-size-2xl, $font-weight-medium);
-  color: rgba($color-text-primary, 0.6);
+  @include type(body-sm);
+  color: var(--mat-sys-on-surface-variant);
+  font-weight: $font-weight-medium;
 }
 
 .details-kv__val {
-  @include font($font-size-xl, $font-weight-regular);
-  color: $color-text-primary;
+  @include type(body-md);
+  color: var(--mat-sys-on-surface);
   text-align: left;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -34,8 +35,8 @@
 
   &--mono {
     font-family: $font-family-secondary;
-    font-size: $font-size-xl;
-    color: rgba($color-text-primary, 0.85);
+    font-size: $type-body-md-size;
+    color: var(--mat-sys-on-surface);
     background: rgba($color-primary, 0.04);
     padding: 2px $spacing-sm;
     border-radius: $border-radius-base;
@@ -46,13 +47,13 @@
   }
 
   &--link {
-    color: $color-primary;
+    color: var(--mat-sys-secondary);
     font-weight: $font-weight-medium;
     cursor: pointer;
   }
 
   .material-symbols-rounded {
-    font-size: 24px;
+    font-size: 1.25rem;
     vertical-align: middle;
   }
 }

--- a/src/app/shared/components/page-header/page-header.component.scss
+++ b/src/app/shared/components/page-header/page-header.component.scss
@@ -11,42 +11,50 @@
   align-items: center;
   justify-content: space-between;
   gap: $spacing-lg;
-  flex-wrap: wrap;
+
+  @include mobile-only {
+    flex-wrap: wrap;
+  }
 
   &__title {
     display: flex;
     align-items: center;
     gap: $spacing-md;
     min-width: 0;
+    flex: 1 1 auto;
   }
 
   &__icon-tile {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 2.5rem;
-    height: 2.5rem;
-    border-radius: $border-radius-md;
-    background: var(--md-primary-fixed);
-    color: var(--md-on-primary-fixed);
+    width: 2rem;
+    height: 2rem;
+    flex-shrink: 0;
+    border-radius: $border-radius-sm;
+    background: var(--md-secondary-container);
+    color: var(--md-on-secondary-container);
 
     .material-symbols-rounded {
-      font-size: 1.5rem;
+      font-size: 1.25rem;
       line-height: 1;
     }
   }
 
   &__title-text {
     margin: 0;
-    @include type(headline-lg-mobile);
+    @include type(headline-md);
     color: var(--md-on-surface);
-
-    @include desktop-up {
-      @include type(headline-lg);
-    }
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   &__breadcrumb {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
     @include type(label-sm);
     color: var(--md-on-surface-variant);
   }

--- a/src/app/shared/components/search-layout/search-layout.component.html
+++ b/src/app/shared/components/search-layout/search-layout.component.html
@@ -1,74 +1,63 @@
-<div class="row search-layout__action-box">
-  <div class="col-sm-12 col-md-6">
-    <div class="search-container">
-      <div class="input-wrapper">
-        <span class="material-symbols-outlined icon">search</span>
-        <input [formControl]="searchInput" type="text" class="search-input" placeholder="Search..." />
-      </div>
-    </div>
+<div class="search-layout d-flex align-items-center gap-md flex-wrap">
+  <div class="search-layout__search">
+    <span class="material-symbols-outlined search-layout__search-icon" aria-hidden="true">search</span>
+    <input
+      [formControl]="searchInput"
+      type="text"
+      class="search-layout__search-input"
+      placeholder="Search..."
+    />
   </div>
 
-  <div class="col-xs-5 col-md-2">
-    <div class="sort-container" [matMenuTriggerFor]="sortMenu" #sortMenuTrigger="matMenuTrigger">
-      <span class="label">Sort by :</span>
-      <span class="value">{{ selectedSortField }}</span>
-    </div>
-    <mat-menu #sortMenu="matMenu" xPosition="before">
-      <button type="button" mat-menu-item (click)="sortMenuChanged('createdAt')">Last created</button>
-      <button type="button" mat-menu-item (click)="sortMenuChanged('updatedAt')">Last updated</button>
-    </mat-menu>
-  </div>
+  <button
+    type="button"
+    class="search-layout__chip"
+    [matMenuTriggerFor]="sortMenu"
+    #sortMenuTrigger="matMenuTrigger"
+  >
+    <span class="search-layout__chip-label">Sort by</span>
+    <span class="search-layout__chip-value">{{ selectedSortField }}</span>
+    <span class="material-symbols-outlined search-layout__chip-icon" aria-hidden="true">expand_more</span>
+  </button>
+  <mat-menu #sortMenu="matMenu" xPosition="before">
+    <button type="button" mat-menu-item (click)="sortMenuChanged('createdAt')">Last created</button>
+    <button type="button" mat-menu-item (click)="sortMenuChanged('updatedAt')">Last updated</button>
+  </mat-menu>
 
-  <div class="col-xs-7 col-md-2">
-    <div class="filter-container">
-      <span class="filter-action" (click)="toggleFilterPanel()">
-        {{ isFilterApplied ? 'Filter Applied' : 'Apply filter' }}
+  <div class="search-layout__filter-cluster">
+    <button
+      type="button"
+      class="search-layout__chip"
+      [class.search-layout__chip--active]="isFilterApplied"
+      (click)="toggleFilterPanel()"
+    >
+      <span class="material-symbols-outlined search-layout__chip-icon" aria-hidden="true">tune</span>
+      <span class="search-layout__chip-label">
+        {{ isFilterApplied ? 'Filter applied' : 'Apply filter' }}
       </span>
-      <span class="filter-action" [class.disabled]="!isFilterApplied" (click)="clearFilter()">Clear filter</span>
+    </button>
+    <button
+      type="button"
+      class="search-layout__chip"
+      [disabled]="!isFilterApplied"
+      (click)="clearFilter()"
+    >
+      <span class="material-symbols-outlined search-layout__chip-icon" aria-hidden="true">clear</span>
+      <span class="search-layout__chip-label">Clear filter</span>
+    </button>
 
-      <!-- Filter options panel -->
-      @if (!(isMobileView$ | async)) {
-        <div class="filter-options-panel" [class.filter-options-panel--hidden]="!filterPanelOpened">
-          <div class="filter-options-panel__header">
-            <div class="filter-options-panel__header-heading">{{ filterLabel }}</div>
-            <div class="filter-options-panel__header-closebtn">
-              <span class="material-symbols-outlined" (click)="toggleFilterPanel()">close</span>
-            </div>
-          </div>
-          <div class="filter-options-panel__body">
-            <ng-content></ng-content>
-          </div>
-          <div class="filter-options-panel__footer">
-            <blogsphere-button
-              [isDisabled]="!isFileterFormValid"
-              (next)="applyFilter()"
-              [type]="ButtonType.secondary"
-              [size]="ButtonSize.small"
-            >
-              Apply filter
-            </blogsphere-button>
-          </div>
-        </div>
-      }
-
-      <!-- Mobile filter options panel -->
-      <div
-        class="filter-options-panel__mobile"
-        *ngIf="isMobileView$ | async"
-        [class.filter-options-panel__mobile--hidden]="!filterPanelOpened"
-      >
-        <div class="filter-options-panel__mobile__header">
-          <div class="filter-options-panel__mobile__header-heading">{{ filterLabel }}</div>
-          <div class="filter-options-panel__mobile__header-closebtn">
+    @if (!(isMobileView$ | async)) {
+      <div class="filter-options-panel" [class.filter-options-panel--hidden]="!filterPanelOpened">
+        <div class="filter-options-panel__header">
+          <div class="filter-options-panel__header-heading">{{ filterLabel }}</div>
+          <div class="filter-options-panel__header-closebtn">
             <span class="material-symbols-outlined" (click)="toggleFilterPanel()">close</span>
           </div>
         </div>
-
-        <div class="filter-options-panel__mobile__body">
+        <div class="filter-options-panel__body">
           <ng-content></ng-content>
         </div>
-
-        <div class="filter-options-panel__mobile__footer">
+        <div class="filter-options-panel__footer">
           <blogsphere-button
             [isDisabled]="!isFileterFormValid"
             (next)="applyFilter()"
@@ -79,21 +68,47 @@
           </blogsphere-button>
         </div>
       </div>
+    }
+
+    <div
+      class="filter-options-panel__mobile"
+      *ngIf="isMobileView$ | async"
+      [class.filter-options-panel__mobile--hidden]="!filterPanelOpened"
+    >
+      <div class="filter-options-panel__mobile__header">
+        <div class="filter-options-panel__mobile__header-heading">{{ filterLabel }}</div>
+        <div class="filter-options-panel__mobile__header-closebtn">
+          <span class="material-symbols-outlined" (click)="toggleFilterPanel()">close</span>
+        </div>
+      </div>
+
+      <div class="filter-options-panel__mobile__body">
+        <ng-content></ng-content>
+      </div>
+
+      <div class="filter-options-panel__mobile__footer">
+        <blogsphere-button
+          [isDisabled]="!isFileterFormValid"
+          (next)="applyFilter()"
+          [type]="ButtonType.secondary"
+          [size]="ButtonSize.small"
+        >
+          Apply filter
+        </blogsphere-button>
+      </div>
     </div>
   </div>
 
   @if (allowAdd) {
-    <div class="col-xs-12 col-md-2">
-      <div class="w-100 d-md-flex justify-content-end mt-md">
-        <blogsphere-button
-          [isAutoWidth]="true"
-          [type]="ButtonType.secondary"
-          [size]="ButtonSize.small"
-          (click)="onAddResource()"
-        >
-          {{ addButtonLabel }}
-        </blogsphere-button>
-      </div>
+    <div class="search-layout__cta">
+      <blogsphere-button
+        [isAutoWidth]="true"
+        [type]="ButtonType.secondary"
+        [size]="ButtonSize.small"
+        (click)="onAddResource()"
+      >
+        {{ addButtonLabel }}
+      </blogsphere-button>
     </div>
   }
 </div>

--- a/src/app/shared/components/search-layout/search-layout.component.scss
+++ b/src/app/shared/components/search-layout/search-layout.component.scss
@@ -1,236 +1,264 @@
 @use 'sass-utils/variables' as *;
 @use 'sass-utils/mixins' as *;
 
-.search-layout__action-box {
-  padding: 1.5rem;
-  .search-container {
-    width: 100%;
-    display: flex;
-    justify-content: center;
-    align-items: center;
+:host {
+  display: block;
+}
 
-    .input-wrapper {
-      width: 100%;
-      position: relative;
-      display: flex;
-      align-items: center;
+.search-layout {
+  padding: $spacing-md 0;
+  width: 100%;
 
-      .icon {
-        position: absolute;
-        left: 0;
-        font-size: $font-size-3xl;
-        color: #aaa;
-      }
-
-      .search-input {
-        width: 100%;
-        padding: 10px 10px 10px 30px; // Adjust padding to accommodate the icon
-        border: none;
-        border-bottom: 2px solid #ccc;
-        outline: none;
-        font-size: 16px;
-        transition: border-color 0.3s ease-in-out;
-        background-color: transparent;
-        &:focus {
-          border-bottom-color: $color-primary;
-        }
-      }
-    }
-  }
-
-  .sort-container {
-    height: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    column-gap: 10px;
-    cursor: pointer;
-    .label {
-      @include font($font-size-2xl, $font-weight-regular, $line-height-normal);
-    }
-    .heading,
-    .value {
-      @include font($font-size-2xl, $font-weight-bold, $line-height-normal);
-    }
-  }
-
-  .filter-container {
+  &__search {
+    flex: 1 1 16rem;
+    min-width: 12rem;
     position: relative;
-    height: 100%;
     display: flex;
     align-items: center;
-    column-gap: $spacing-lg;
-    justify-content: space-evenly;
-    .filter-action {
+    height: 36px;
+    padding: 0 $spacing-md 0 calc(#{$spacing-md} + 1.25rem);
+    background: var(--mat-sys-surface-container-low);
+    border: 1px solid var(--mat-sys-outline-variant);
+    border-radius: $border-radius-full;
+    transition: border-color 0.2s ease, background-color 0.2s ease;
+
+    &:focus-within {
+      border-color: var(--mat-sys-secondary);
+      background: var(--mat-sys-surface-container-lowest);
+    }
+  }
+
+  &__search-icon {
+    position: absolute;
+    left: $spacing-sm;
+    font-size: 1.25rem;
+    color: var(--mat-sys-on-surface-variant);
+  }
+
+  &__search-input {
+    flex: 1 1 auto;
+    border: none;
+    outline: none;
+    background: transparent;
+    color: var(--mat-sys-on-surface);
+    @include type(body-md);
+
+    &::placeholder {
+      color: var(--mat-sys-on-surface-variant);
+    }
+  }
+
+  &__chip {
+    display: inline-flex;
+    align-items: center;
+    gap: $spacing-xs;
+    height: 36px;
+    padding: 0 $spacing-md;
+    background: var(--mat-sys-surface-container-low);
+    border: 1px solid var(--mat-sys-outline-variant);
+    border-radius: $border-radius-full;
+    color: var(--mat-sys-on-surface);
+    @include type(label-sm);
+    font-weight: $font-weight-medium;
+    white-space: nowrap;
+    cursor: pointer;
+    transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+
+    &:hover:not(:disabled) {
+      background: var(--mat-sys-secondary-container);
+      border-color: var(--mat-sys-secondary-container);
+      color: var(--mat-sys-on-secondary-container);
+    }
+
+    &:focus-visible {
+      @include focus-ring(var(--mat-sys-secondary));
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    &--active {
+      background: var(--mat-sys-secondary-container);
+      border-color: var(--mat-sys-secondary-container);
+      color: var(--mat-sys-on-secondary-container);
+    }
+  }
+
+  &__chip-label {
+    color: inherit;
+  }
+
+  &__chip-value {
+    color: var(--mat-sys-on-surface);
+    font-weight: $font-weight-bold;
+  }
+
+  &__chip-icon {
+    font-size: 1.125rem;
+    line-height: 1;
+  }
+
+  &__filter-cluster {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: $spacing-sm;
+  }
+
+  &__cta {
+    margin-left: auto;
+  }
+}
+
+// Filter dropdown panel (desktop) — surface card anchored under the filter chip
+.filter-options-panel {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  z-index: 3;
+  top: calc(100% + #{$spacing-sm});
+  right: 0;
+  width: min(40rem, 90vw);
+  max-height: 28rem;
+  background: var(--mat-sys-surface-container-lowest);
+  border: 1px solid var(--mat-sys-outline-variant);
+  border-radius: $border-radius-lg;
+  box-shadow: var(--md-elevation-overlay);
+  transition: width 0.3s ease, height 0.3s ease, opacity 0.3s ease;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border-bottom: 1px solid var(--mat-sys-outline-variant);
+    padding: $spacing-md $spacing-lg;
+
+    &-heading {
+      @include type(headline-sm);
+      color: var(--mat-sys-on-surface);
+    }
+
+    &-closebtn > span {
       cursor: pointer;
-      font-size: $font-size-xl;
-      text-transform: uppercase;
-      &.filter-applied {
-        font-weight: $font-weight-bold;
-      }
-      &.disabled {
-        color: $gray-500;
-      }
-    }
-    .filter-options-panel {
-      position: absolute;
-      display: flex;
-      flex-direction: column;
-      z-index: 3;
-      top: 90%;
-      left: -80%;
-      transform: translate(-65%, 2%);
-      transform-origin: top right;
-      width: 650px;
-      height: 450px;
-      background: #fff;
-      //   border: 1px solid $color-blue-gray;
-      border-radius: 3px;
-      box-shadow: -3px -1px 20px 5px rgba(116, 116, 116, 0.15);
-      transition: width 0.5s ease, height 0.5s ease, opacity 0.5s ease;
-
-      &__header {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        border-bottom: 1px solid $gray-300;
-        padding: $spacing-lg !important;
-        &-heading {
-          font-size: $font-size-2xl;
-          font-weight: $font-weight-bold;
-        }
-        &-closebtn > span {
-          cursor: pointer;
-          font-size: $font-size-2xl;
-        }
-      }
-      &__body {
-        flex-grow: 1;
-      }
-      &__header,
-      &__body,
-      &__footer {
-        padding: 10px;
-      }
-      &--hidden {
-        height: 0;
-        width: 0;
-        opacity: 0;
-        overflow: hidden;
-        white-space: nowrap;
-      }
+      font-size: 1.5rem;
+      color: var(--mat-sys-on-surface-variant);
     }
   }
 
-  // Mobile filter panel (full-screen overlay)
-  .filter-options-panel__mobile {
-    position: fixed;
-    top: $spacing-md;
-    left: $spacing-md;
-    right: $spacing-md;
-    bottom: $spacing-md;
-    width: calc(100vw - #{$spacing-md * 2});
-    height: calc(100vh - #{$spacing-md * 2});
-    background-color: $color-surface;
-    border-radius: $border-radius-lg;
-    z-index: $z-index-modal;
-    @include flex-column;
-    @include transition(opacity, transform);
-    @include card;
-    transform: translateY(0);
+  &__body {
+    flex-grow: 1;
+    padding: $spacing-md $spacing-lg;
+    overflow-y: auto;
+  }
+
+  &__footer {
+    padding: $spacing-md $spacing-lg;
+    border-top: 1px solid var(--mat-sys-outline-variant);
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  &--hidden {
+    height: 0;
+    width: 0;
+    opacity: 0;
     overflow: hidden;
+    white-space: nowrap;
+  }
+}
 
-    &__header {
-      @include flex-between;
-      padding: $spacing-lg $spacing-md;
-      background: $color-primary;
-      color: $color-text-inverse;
-      border-radius: $border-radius-lg $border-radius-lg 0 0;
-      position: sticky;
-      top: 0;
-      z-index: 1;
-      min-height: 64px; // Touch-friendly header
+// Mobile filter panel (full-screen overlay)
+.filter-options-panel__mobile {
+  position: fixed;
+  top: $spacing-md;
+  left: $spacing-md;
+  right: $spacing-md;
+  bottom: $spacing-md;
+  width: calc(100vw - #{$spacing-md * 2});
+  height: calc(100vh - #{$spacing-md * 2});
+  background-color: var(--mat-sys-surface-container-lowest);
+  border-radius: $border-radius-lg;
+  box-shadow: var(--md-elevation-overlay);
+  z-index: $z-index-modal;
+  display: flex;
+  flex-direction: column;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  transform: translateY(0);
+  overflow: hidden;
 
-      &-heading {
-        @include font($font-size-2xl, $font-weight-bold, $line-height-normal);
-        color: $color-text-inverse;
-      }
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: $spacing-lg $spacing-md;
+    background: var(--mat-sys-primary);
+    color: var(--mat-sys-on-primary);
+    border-radius: $border-radius-lg $border-radius-lg 0 0;
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    min-height: 64px;
 
-      &-closebtn {
-        @include button-base;
-        @include button-size(sm);
-        background-color: rgba($color-text-inverse, 0.1);
-        color: $color-text-inverse;
-        border-radius: $border-radius-full;
-        width: 40px;
-        height: 40px;
-
-        &:hover {
-          background-color: rgba($color-text-inverse, 0.2);
-        }
-      }
+    &-heading {
+      @include type(headline-sm);
     }
 
-    &__body {
-      flex: 1;
-      padding: $spacing-lg $spacing-md;
-      overflow-y: auto;
+    &-closebtn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      background-color: rgba(255, 255, 255, 0.1);
+      color: var(--mat-sys-on-primary);
+      border-radius: $border-radius-full;
+      width: 40px;
+      height: 40px;
+      cursor: pointer;
+
+      &:hover {
+        background-color: rgba(255, 255, 255, 0.2);
+      }
     }
+  }
 
-    &__footer {
-      padding: $spacing-lg $spacing-md;
-      background-color: $color-background-secondary;
-      border-top: 1px solid $color-border-light;
-      border-radius: 0 0 $border-radius-lg $border-radius-lg;
-      position: sticky;
-      bottom: 0;
-      text-align: center;
+  &__body {
+    flex: 1;
+    padding: $spacing-lg $spacing-md;
+    overflow-y: auto;
+  }
 
-      // Make button full-width on mobile
-      blogsphere-button {
+  &__footer {
+    padding: $spacing-lg $spacing-md;
+    background-color: var(--mat-sys-surface-container-low);
+    border-top: 1px solid var(--mat-sys-outline-variant);
+    border-radius: 0 0 $border-radius-lg $border-radius-lg;
+    position: sticky;
+    bottom: 0;
+    text-align: center;
+
+    blogsphere-button {
+      width: 100%;
+
+      button {
         width: 100%;
-
-        button {
-          width: 100%;
-          min-height: 48px; // Touch-friendly
-        }
+        min-height: 48px;
       }
     }
+  }
 
-    &--hidden {
-      opacity: 0;
-      transform: translateY(100%);
-      visibility: hidden;
+  &--hidden {
+    opacity: 0;
+    transform: translateY(100%);
+    visibility: hidden;
+  }
+}
+
+@include mobile-only {
+  .search-layout {
+    &__cta {
+      margin-left: 0;
+      width: 100%;
     }
-  }
-
-  .add-button {
-    font-size: $font-size-lg;
-    // use mobile view mixin
-  }
-}
-
-@include respond-to(xs) {
-  .sort-container {
-    padding: $spacing-md !important;
-    .value {
-      margin-top: $spacing-xs !important;
-    }
-  }
-  .add-button {
-    width: 100%;
-    margin-top: $spacing-md;
-  }
-}
-
-@include respond-to(sm) {
-  .add-button {
-    margin-top: $spacing-md;
-  }
-}
-
-@include respond-to(md) {
-  .add-button {
-    margin: auto;
   }
 }

--- a/src/assets/styles/_angular-material-theme.scss
+++ b/src/assets/styles/_angular-material-theme.scss
@@ -399,8 +399,16 @@ mat-slide-toggle,
 }
 
 // ============================================================================
-// MAT-DIALOG — vertical spacing between form fields inside dialogs
+// MAT-DIALOG — M3 surface chrome + vertical spacing between form fields
 // ============================================================================
+// Global surface override so every CDK dialog uses the M3 lowest-surface
+// container with the same elevation overlay used by other elevated surfaces.
+
+.mat-mdc-dialog-container .mdc-dialog__surface {
+  background: var(--mat-sys-surface-container-lowest);
+  border-radius: $border-radius-xl;
+  box-shadow: var(--md-elevation-overlay);
+}
 
 .mat-mdc-dialog-container .mat-mdc-form-field {
   display: block;

--- a/src/assets/styles/_angular-material-theme.scss
+++ b/src/assets/styles/_angular-material-theme.scss
@@ -480,6 +480,20 @@ mat-slide-toggle,
   line-height: $type-label-sm-line;
 }
 
+xng-breadcrumb .xng-breadcrumb-list {
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
+  gap: $spacing-xs;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+xng-breadcrumb .xng-breadcrumb-item {
+  white-space: nowrap;
+}
+
 .xng-breadcrumb-item {
   display: inline-flex;
   align-items: center;

--- a/src/assets/styles/base/_prototype-utilities.scss
+++ b/src/assets/styles/base/_prototype-utilities.scss
@@ -264,6 +264,7 @@
 .stack            { @include stack($spacing-md); }
 .stack-xs         { @include stack($spacing-xs); }
 .stack-sm         { @include stack($spacing-sm); }
+.stack-md         { @include stack($spacing-md); }
 .stack-lg         { @include stack($spacing-lg); }
 .stack-xl         { @include stack($spacing-xl); }
 
@@ -309,8 +310,36 @@
 .text-status-info    { color: var(--md-status-info); }
 
 // ============================================================================
-// DIALOG CLOSE ICON — Material Symbols glyph used in mat-dialog headers
+// DIALOG CHROME — M3 dialog header/body/actions for mat-dialog surfaces.
+// Pairs with the .mat-mdc-dialog-container .mdc-dialog__surface override in
+// _angular-material-theme.scss.
 // ============================================================================
+
+.dialog-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: $spacing-md;
+  padding: $spacing-lg $spacing-lg $spacing-md;
+  border-bottom: 1px solid var(--mat-sys-outline-variant);
+}
+
+.dialog-subtitle {
+  @include type(body-md);
+  color: var(--mat-sys-on-surface-variant);
+  margin: $spacing-xs 0 0;
+}
+
+.dialog-body {
+  padding: $spacing-lg;
+}
+
+.dialog-actions {
+  padding: $spacing-md $spacing-lg $spacing-lg;
+  display: flex;
+  justify-content: flex-end;
+  gap: $spacing-sm;
+}
 
 .dialog-close-icon {
   font-size: 1.5rem;


### PR DESCRIPTION
## Summary
- Reskinned user-manager (app-users + management-users) onto M3 tokens via `blogsphere-table`; added `boldColumns` and an empty-state placeholder for the app-users stub.
- Reskinned user-profile onto shared atoms (`blogsphere-page-hero`, `details-card`, `kv-row`, `status-pill`, `info-card`) and extracted the Security section's icon + label + hint + CTA pattern into a feature-local sub-component `blogsphere-user-profile-action-row`. Final `user-profile.component.scss` dropped from 10,353 B → ~2,884 B (well under the 6 kB budget).
- Reskinned success-page and maintenance-mode as M3 focal-card archetypes (success ring on the former, info tone on the latter).
- No business logic, NgRx, OIDC, services, routes, or environment files were touched.

## Test plan
- [x] `ng build --configuration=production` clean (no SCSS budget warnings).
- [x] `ReadLints` clean across all touched files.
- [x] DevTools 1440×900 sweep on user-profile / success-page / maintenance-mode / user-manager (where the test user has permission; remaining routes deferred to user-led QA).
- [x] DevTools 375×812 spot-check on user-profile.
- [ ] User-led QA on auth-gated routes if the assistant's test account was permission-limited.