### PR TITLE
feat(ui): cluster & route details — page-hero, stat tiles, layout parity

### DIFF
--- a/src/app/features/api-cluster/cluster-details/cluster-details.component.html
+++ b/src/app/features/api-cluster/cluster-details/cluster-details.component.html
@@ -9,6 +9,7 @@
         <blogsphere-page-hero-avatar
           hero-avatar
           shape="circle"
+          size="small"
           icon="hub"
           [isActive]="c.isActive"
           [isInactive]="!c.isActive"
@@ -54,7 +55,7 @@
 
       <section class="row gutter-sm cd-grid-row" aria-label="Cluster metrics">
         <div class="col-6 col-md-4">
-          <blogsphere-stat-tile
+          <blogsphere-stat-tile [compact]="true"
             [tone]="c.isActive ? 'success' : 'warning'"
             [icon]="c.isActive ? 'toggle_on' : 'toggle_off'"
             [value]="c.isActive ? 'Active' : 'Inactive'"
@@ -62,7 +63,7 @@
           ></blogsphere-stat-tile>
         </div>
         <div class="col-6 col-md-4">
-          <blogsphere-stat-tile
+          <blogsphere-stat-tile [compact]="true"
             tone="info"
             icon="account_tree"
             [value]="c.loadBalancingPolicy || 'N/A'"
@@ -70,7 +71,7 @@
           ></blogsphere-stat-tile>
         </div>
         <div class="col-6 col-md-4">
-          <blogsphere-stat-tile
+          <blogsphere-stat-tile [compact]="true"
             [tone]="c.healthCheckEnabled ? 'success' : 'danger'"
             [icon]="c.healthCheckEnabled ? 'heart_plus' : 'heart_broken'"
             [value]="c.healthCheckEnabled ? 'Enabled' : 'Disabled'"
@@ -78,7 +79,7 @@
           ></blogsphere-stat-tile>
         </div>
         <div class="col-6 col-md-4">
-          <blogsphere-stat-tile
+          <blogsphere-stat-tile [compact]="true"
             tone="primary"
             icon="directions_run"
             [value]="(c.destinations || []).length"
@@ -86,7 +87,7 @@
           ></blogsphere-stat-tile>
         </div>
         <div class="col-6 col-md-4">
-          <blogsphere-stat-tile
+          <blogsphere-stat-tile [compact]="true"
             tone="primary"
             icon="route"
             [value]="(c.routes || []).length"

--- a/src/app/features/api-cluster/cluster-details/cluster-details.component.html
+++ b/src/app/features/api-cluster/cluster-details/cluster-details.component.html
@@ -1,113 +1,173 @@
 @if (!(isClusterLoading$ | async) && clusterDetails$ | async; as c) {
   <div class="cd">
-    <blogsphere-hero-header
-      icon="route"
-      [title]="c.clusterId | capitalize"
-      subtitle="Manage configuration, destinations and routes for this API cluster."
-      [isJsonView]="isJsonView"
-      (edit)="goToEdit()"
-      (toggleView)="toggleJsonView()"
-      (delete)="openDeleteDialog()"
-      [showEditButton]="true"
-      [showDeleteButton]="false"
-    ></blogsphere-hero-header>
-    <section class="cd-stats">
-      <div class="cd-stat">
-        <div class="cd-stat__label">Status</div>
-        <div class="cd-stat__value">
-          <blogsphere-badge [type]="c.isActive ? BadgeType.success : BadgeType.danger" [isRounded]="true">
-            {{ c.isActive ? 'Active' : 'Inactive' }}
-          </blogsphere-badge>
-        </div>
-      </div>
-      <div class="cd-stat">
-        <div class="cd-stat__label">Load balancing</div>
-        <div class="cd-stat__value">{{ c.loadBalancingPolicy || 'N/A' }}</div>
-      </div>
-      <div class="cd-stat">
-        <div class="cd-stat__label">Health check</div>
-        <div class="cd-stat__value">
-          <blogsphere-badge [type]="c.healthCheckEnabled ? BadgeType.success : BadgeType.danger" [isRounded]="true">
-            {{ c.healthCheckEnabled ? 'Enabled' : 'Disabled' }}
-          </blogsphere-badge>
-        </div>
-      </div>
-      <div class="cd-stat">
-        <div class="cd-stat__label">Destinations</div>
-        <div class="cd-stat__value">{{ (c.destinations || []).length }}</div>
-      </div>
-      <div class="cd-stat">
-        <div class="cd-stat__label">Routes</div>
-        <div class="cd-stat__value">{{ (c.routes || []).length }}</div>
-      </div>
-    </section>
     @if (!isJsonView) {
-      <blogsphere-details-card mode="keyValue" icon="settings" title="Core configuration">
-        <blogsphere-kv-row label="Cluster id">{{ c.clusterId }}</blogsphere-kv-row>
-        <blogsphere-kv-row label="Unique id" variant="mono">{{ c.id }}</blogsphere-kv-row>
-        <blogsphere-kv-row label="Active">
-          @if (c.isActive) {
-            <span class="material-symbols-rounded text-success">check_circle</span>
-          }
-          @if (!c.isActive) {
-            <span class="material-symbols-rounded text-error">cancel</span>
-          }
-        </blogsphere-kv-row>
-        <blogsphere-kv-row label="Load balancing policy">{{ c.loadBalancingPolicy || 'N/A' }}</blogsphere-kv-row>
-        <blogsphere-kv-row label="Health check enabled">
-          @if (c.healthCheckEnabled) {
-            <span class="material-symbols-rounded text-success">check_circle</span>
-          }
-          @if (!c.healthCheckEnabled) {
-            <span class="material-symbols-rounded text-error">cancel</span>
-          }
-        </blogsphere-kv-row>
-        <blogsphere-kv-row label="Health check path" variant="mono">{{ c.healthCheckPath || 'N/A' }}</blogsphere-kv-row>
-        <blogsphere-kv-row label="Health check interval">{{ c.healthCheckInterval ?? 'N/A' }}</blogsphere-kv-row>
-        <blogsphere-kv-row label="Health check timeout">{{ c.healthCheckTimeout ?? 'N/A' }}</blogsphere-kv-row>
-      </blogsphere-details-card>
-      <blogsphere-details-card mode="keyValue" icon="history" title="Audit">
-        <blogsphere-kv-row label="Created">{{ formatDate(c.metaData?.createdAt) }}</blogsphere-kv-row>
-        <blogsphere-kv-row label="Updated">{{ formatDate(c.metaData?.updatedAt) }}</blogsphere-kv-row>
-        <blogsphere-kv-row label="Created by">
-          <span #triggerRefCreatedBy class="cursor-pointer">{{ c.metaData?.createdBy?.fullName || 'N/A' }}</span>
-          @if (c.metaData?.createdBy) {
-            <blogsphere-tooltip [trigger]="triggerRefCreatedBy" position="below">
-              <p>
-                <strong>Email:</strong>
-                {{ c.metaData.createdBy.email }}
-              </p>
-              <p>
-                <strong>Role:</strong>
-                {{ c.metaData.createdBy.jobTitle }}
-              </p>
-              <p>
-                <strong>Employee Id:</strong>
-                {{ c.metaData.createdBy.employeeId }}
-              </p>
-            </blogsphere-tooltip>
-          }
-        </blogsphere-kv-row>
-        <blogsphere-kv-row label="Updated by">
-          <span #triggerRefUpdatedBy class="cursor-pointer">{{ c.metaData?.updatedBy?.fullName || 'N/A' }}</span>
-          @if (c.metaData?.updatedBy) {
-            <blogsphere-tooltip [trigger]="triggerRefUpdatedBy" position="below">
-              <p>
-                <strong>Email:</strong>
-                {{ c.metaData.updatedBy.email }}
-              </p>
-              <p>
-                <strong>Role:</strong>
-                {{ c.metaData.updatedBy.jobTitle }}
-              </p>
-              <p>
-                <strong>Employee Id:</strong>
-                {{ c.metaData.updatedBy.employeeId }}
-              </p>
-            </blogsphere-tooltip>
-          }
-        </blogsphere-kv-row>
-      </blogsphere-details-card>
+      <blogsphere-page-hero
+        [title]="c.clusterId | capitalize"
+        subtitle="Manage configuration, destinations and routes for this API cluster."
+        [compact]="true"
+      >
+        <blogsphere-page-hero-avatar
+          hero-avatar
+          shape="circle"
+          icon="hub"
+          [isActive]="c.isActive"
+          [isInactive]="!c.isActive"
+        ></blogsphere-page-hero-avatar>
+
+        <div hero-body class="cd-hero-body">
+          <p class="cd-hero-body__line">
+            <span class="material-symbols-rounded cd-hero-body__icon">account_tree</span>
+            <span class="cd-hero-body__text">{{ c.loadBalancingPolicy || 'N/A' }}</span>
+          </p>
+          <p class="cd-hero-body__line" [matTooltip]="c.healthCheckPath || 'No health check path'">
+            <span class="material-symbols-rounded cd-hero-body__icon">monitor_heart</span>
+            <code class="cd-hero-body__code">{{ c.healthCheckPath || 'N/A' }}</code>
+          </p>
+        </div>
+
+        <div hero-actions class="cd-hero-actions">
+          <blogsphere-button [type]="ButtonType.secondary" [size]="ButtonSize.small" (next)="goToEdit()">
+            <span class="material-symbols-rounded cd-hero-btn-icon">edit</span>
+            Edit
+          </blogsphere-button>
+          <blogsphere-button [type]="ButtonType.secondary" [size]="ButtonSize.small" (next)="toggleJsonView()">
+            <span class="material-symbols-rounded cd-hero-btn-icon">data_object</span>
+            JSON view
+          </blogsphere-button>
+        </div>
+
+        <ng-container hero-contact>
+          <span class="cd-hero-contact-item" [matTooltip]="'Unique cluster id'">
+            <span class="material-symbols-rounded cd-hero-contact-item__icon">tag</span>
+            <span class="cd-hero-contact-item__text cd-hero-contact-item__text--mono">{{ c.id }}</span>
+          </span>
+          <a
+            class="cd-hero-contact-item cd-hero-contact-item__link"
+            [routerLink]="['/api-route', 'route-setup']"
+            [matTooltip]="'Create a new route'"
+          >
+            <span class="material-symbols-rounded cd-hero-contact-item__icon">add_road</span>
+            <span>New route</span>
+          </a>
+        </ng-container>
+      </blogsphere-page-hero>
+
+      <section class="row gutter-sm cd-grid-row" aria-label="Cluster metrics">
+        <div class="col-6 col-md-4">
+          <blogsphere-stat-tile
+            [tone]="c.isActive ? 'success' : 'warning'"
+            [icon]="c.isActive ? 'toggle_on' : 'toggle_off'"
+            [value]="c.isActive ? 'Active' : 'Inactive'"
+            label="Status"
+          ></blogsphere-stat-tile>
+        </div>
+        <div class="col-6 col-md-4">
+          <blogsphere-stat-tile
+            tone="info"
+            icon="account_tree"
+            [value]="c.loadBalancingPolicy || 'N/A'"
+            label="Load balancing"
+          ></blogsphere-stat-tile>
+        </div>
+        <div class="col-6 col-md-4">
+          <blogsphere-stat-tile
+            [tone]="c.healthCheckEnabled ? 'success' : 'danger'"
+            [icon]="c.healthCheckEnabled ? 'heart_plus' : 'heart_broken'"
+            [value]="c.healthCheckEnabled ? 'Enabled' : 'Disabled'"
+            label="Health check"
+          ></blogsphere-stat-tile>
+        </div>
+        <div class="col-6 col-md-4">
+          <blogsphere-stat-tile
+            tone="primary"
+            icon="directions_run"
+            [value]="(c.destinations || []).length"
+            label="Destinations"
+          ></blogsphere-stat-tile>
+        </div>
+        <div class="col-6 col-md-4">
+          <blogsphere-stat-tile
+            tone="primary"
+            icon="route"
+            [value]="(c.routes || []).length"
+            label="Routes"
+          ></blogsphere-stat-tile>
+        </div>
+      </section>
+
+      <div class="row cd-grid-row cd-card-grid align-items-stretch">
+        <div class="col-12 col-md-6">
+          <blogsphere-details-card mode="keyValue" icon="settings" title="Core configuration">
+            <blogsphere-kv-row label="Cluster id">{{ c.clusterId }}</blogsphere-kv-row>
+            <blogsphere-kv-row label="Unique id" variant="mono">{{ c.id }}</blogsphere-kv-row>
+            <blogsphere-kv-row label="Active">
+              @if (c.isActive) {
+                <span class="material-symbols-rounded text-success">check_circle</span>
+              }
+              @if (!c.isActive) {
+                <span class="material-symbols-rounded text-error">cancel</span>
+              }
+            </blogsphere-kv-row>
+            <blogsphere-kv-row label="Load balancing policy">{{ c.loadBalancingPolicy || 'N/A' }}</blogsphere-kv-row>
+            <blogsphere-kv-row label="Health check enabled">
+              @if (c.healthCheckEnabled) {
+                <span class="material-symbols-rounded text-success">check_circle</span>
+              }
+              @if (!c.healthCheckEnabled) {
+                <span class="material-symbols-rounded text-error">cancel</span>
+              }
+            </blogsphere-kv-row>
+            <blogsphere-kv-row label="Health check path" variant="mono">{{ c.healthCheckPath || 'N/A' }}</blogsphere-kv-row>
+            <blogsphere-kv-row label="Health check interval">{{ c.healthCheckInterval ?? 'N/A' }}</blogsphere-kv-row>
+            <blogsphere-kv-row label="Health check timeout">{{ c.healthCheckTimeout ?? 'N/A' }}</blogsphere-kv-row>
+          </blogsphere-details-card>
+        </div>
+        <div class="col-12 col-md-6">
+          <blogsphere-details-card mode="keyValue" icon="history" title="Audit">
+            <blogsphere-kv-row label="Created">{{ formatDate(c.metaData?.createdAt) }}</blogsphere-kv-row>
+            <blogsphere-kv-row label="Updated">{{ formatDate(c.metaData?.updatedAt) }}</blogsphere-kv-row>
+            <blogsphere-kv-row label="Created by">
+              <span #triggerRefCreatedBy class="cursor-pointer">{{ c.metaData?.createdBy?.fullName || 'N/A' }}</span>
+              @if (c.metaData?.createdBy) {
+                <blogsphere-tooltip [trigger]="triggerRefCreatedBy" position="below">
+                  <p>
+                    <strong>Email:</strong>
+                    {{ c.metaData.createdBy.email }}
+                  </p>
+                  <p>
+                    <strong>Role:</strong>
+                    {{ c.metaData.createdBy.jobTitle }}
+                  </p>
+                  <p>
+                    <strong>Employee Id:</strong>
+                    {{ c.metaData.createdBy.employeeId }}
+                  </p>
+                </blogsphere-tooltip>
+              }
+            </blogsphere-kv-row>
+            <blogsphere-kv-row label="Updated by">
+              <span #triggerRefUpdatedBy class="cursor-pointer">{{ c.metaData?.updatedBy?.fullName || 'N/A' }}</span>
+              @if (c.metaData?.updatedBy) {
+                <blogsphere-tooltip [trigger]="triggerRefUpdatedBy" position="below">
+                  <p>
+                    <strong>Email:</strong>
+                    {{ c.metaData.updatedBy.email }}
+                  </p>
+                  <p>
+                    <strong>Role:</strong>
+                    {{ c.metaData.updatedBy.jobTitle }}
+                  </p>
+                  <p>
+                    <strong>Employee Id:</strong>
+                    {{ c.metaData.updatedBy.employeeId }}
+                  </p>
+                </blogsphere-tooltip>
+              }
+            </blogsphere-kv-row>
+          </blogsphere-details-card>
+        </div>
+      </div>
+
       <blogsphere-details-card
         mode="table"
         icon="directions_run"
@@ -127,17 +187,37 @@
         [tableHeaders]="routesTableHeaders"
         [tableRows]="routesTableRows"
         [compactTable]="true"
-        >
+      >
         <div empty class="cd-empty">
           <span class="material-symbols-rounded cd-empty__icon">route</span>
           <p class="cd-empty__text">No routes found for this cluster.</p>
-          <blogsphere-button [type]="ButtonType.secondary" [size]="ButtonSize.small" (click)="goToRoutes()">
+          <blogsphere-button [type]="ButtonType.secondary" [size]="ButtonSize.small" (next)="goToRoutes()">
             Add route
           </blogsphere-button>
         </div>
       </blogsphere-details-card>
     }
+
     @if (isJsonView) {
+      <blogsphere-page-hero [title]="c.clusterId | capitalize" [subtitle]="c.id" [compact]="true">
+        <blogsphere-page-hero-avatar
+          hero-avatar
+          shape="square"
+          size="small"
+          icon="hub"
+        ></blogsphere-page-hero-avatar>
+
+        <blogsphere-button
+          hero-actions
+          [type]="ButtonType.secondary"
+          [size]="ButtonSize.small"
+          (next)="toggleJsonView()"
+        >
+          <span class="material-symbols-rounded cd-hero-btn-icon">table_chart</span>
+          Table view
+        </blogsphere-button>
+      </blogsphere-page-hero>
+
       <blogsphere-details-card mode="keyValue" icon="data_object" title="Raw JSON" [flushBody]="true">
         <div class="details-json">
           <pre class="details-json__pre">{{ c | json }}</pre>

--- a/src/app/features/api-cluster/cluster-details/cluster-details.component.scss
+++ b/src/app/features/api-cluster/cluster-details/cluster-details.component.scss
@@ -4,13 +4,13 @@
 .cd {
   max-width: $container-max;
   margin: 0 auto;
-  padding: $spacing-md $spacing-lg $spacing-2xl;
+  padding: $spacing-sm $spacing-md $spacing-lg;
   @include flex-column;
-  gap: $spacing-md;
+  gap: $spacing-sm;
 
   @include mobile-only {
-    padding: $spacing-sm $spacing-md $spacing-xl;
-    gap: $spacing-md;
+    padding: $spacing-xs $spacing-sm $spacing-md;
+    gap: $spacing-sm;
   }
 }
 
@@ -22,8 +22,8 @@
   &__line {
     @include cluster($spacing-xs);
     max-width: 100%;
-    margin: 0 0 $spacing-sm;
-    font-size: $type-body-md-size;
+    margin: 0 0 $spacing-xs;
+    font-size: $type-body-sm-size;
     color: var(--mat-sys-on-surface-variant);
 
     &:last-child {
@@ -36,7 +36,7 @@
   }
 
   &__icon {
-    font-size: 1.125rem;
+    font-size: 1rem;
     line-height: 1;
     color: var(--mat-sys-on-surface-variant);
     flex-shrink: 0;
@@ -44,6 +44,7 @@
 
   &__text {
     font-weight: $font-weight-medium;
+    font-size: $type-body-sm-size;
     color: var(--mat-sys-on-surface);
     word-break: break-word;
     min-width: 0;
@@ -51,13 +52,13 @@
 
   &__code {
     font-family: $font-family-mono;
-    font-size: $type-body-sm-size;
+    font-size: $font-size-xs;
     font-weight: $font-weight-medium;
     color: var(--mat-sys-on-surface);
     background: var(--mat-sys-surface-container);
     border: 1px solid var(--mat-sys-outline-variant);
-    border-radius: $border-radius-md;
-    padding: 4px $spacing-sm;
+    border-radius: $border-radius-sm;
+    padding: 2px $spacing-xs;
     @include text-truncate;
     max-width: 100%;
   }
@@ -68,18 +69,18 @@
 }
 
 .cd-hero-btn-icon {
-  font-size: 1.125rem;
+  font-size: 1rem;
   line-height: 1;
 }
 
 .cd-hero-contact-item {
   @include cluster($spacing-xs);
-  font-size: $type-body-sm-size;
+  font-size: $font-size-xs;
   color: var(--mat-sys-on-surface-variant);
   min-width: 0;
 
   &__icon {
-    font-size: 1.125rem;
+    font-size: 1rem;
     line-height: 1;
     color: var(--mat-sys-on-surface-variant);
     flex-shrink: 0;
@@ -100,7 +101,7 @@
     color: var(--mat-sys-primary);
     text-decoration: none;
     font-weight: $font-weight-medium;
-    font-size: $type-body-sm-size;
+    font-size: $font-size-xs;
     transition: color 200ms ease;
 
     &:hover {
@@ -123,6 +124,36 @@
 
 :host ::ng-deep .cd-card-grid .details-card__body {
   flex: 1;
+}
+
+// Compact page-hero inside this shell only
+:host ::ng-deep .cd .page-hero.page-hero--compact {
+  .page-hero__main--compact {
+    padding: $spacing-md $spacing-lg;
+    gap: $spacing-sm;
+
+    @include respond-to(xs) {
+      padding: $spacing-sm $spacing-md;
+    }
+  }
+
+  .page-hero__contact {
+    gap: $spacing-sm;
+    padding: $spacing-sm $spacing-lg;
+
+    @include respond-to(xs) {
+      padding: $spacing-sm $spacing-md;
+    }
+  }
+
+  .page-hero__name--sm {
+    @include heading(6);
+  }
+
+  .page-hero__subtitle {
+    @include font($font-size-xs, $font-weight-regular);
+    margin-top: 2px;
+  }
 }
 
 .cd-empty {

--- a/src/app/features/api-cluster/cluster-details/cluster-details.component.scss
+++ b/src/app/features/api-cluster/cluster-details/cluster-details.component.scss
@@ -14,37 +14,115 @@
   }
 }
 
-.cd-stats {
-  @include grid-auto-fit(12.5rem, $spacing-md);
-
-  @include mobile-only {
-    grid-template-columns: 1fr 1fr;
-  }
+.cd-grid-row {
+  margin-bottom: 0;
 }
 
-.cd-stat {
-  @include md-card($padding: $spacing-md $spacing-lg);
-  @include flex-column;
-  gap: $spacing-xs;
-  border-left: 3px solid var(--mat-sys-secondary);
-  transition: box-shadow 200ms ease, transform 200ms ease;
+.cd-hero-body {
+  &__line {
+    @include cluster($spacing-xs);
+    max-width: 100%;
+    margin: 0 0 $spacing-sm;
+    font-size: $type-body-md-size;
+    color: var(--mat-sys-on-surface-variant);
 
-  &:hover {
-    box-shadow: var(--md-elevation-card-hover);
-    transform: translateY(-1px);
+    &:last-child {
+      margin-bottom: 0;
+    }
+
+    @include mobile-only {
+      justify-content: center;
+    }
   }
 
-  &__label {
-    @include eyebrow-label(var(--mat-sys-on-surface-variant));
+  &__icon {
+    font-size: 1.125rem;
+    line-height: 1;
+    color: var(--mat-sys-on-surface-variant);
+    flex-shrink: 0;
   }
 
-  &__value {
-    font-size: $type-headline-sm-size;
-    line-height: $type-headline-sm-line;
+  &__text {
     font-weight: $font-weight-medium;
     color: var(--mat-sys-on-surface);
     word-break: break-word;
+    min-width: 0;
   }
+
+  &__code {
+    font-family: $font-family-mono;
+    font-size: $type-body-sm-size;
+    font-weight: $font-weight-medium;
+    color: var(--mat-sys-on-surface);
+    background: var(--mat-sys-surface-container);
+    border: 1px solid var(--mat-sys-outline-variant);
+    border-radius: $border-radius-md;
+    padding: 4px $spacing-sm;
+    @include text-truncate;
+    max-width: 100%;
+  }
+}
+
+.cd-hero-actions {
+  @include cluster($spacing-sm);
+}
+
+.cd-hero-btn-icon {
+  font-size: 1.125rem;
+  line-height: 1;
+}
+
+.cd-hero-contact-item {
+  @include cluster($spacing-xs);
+  font-size: $type-body-sm-size;
+  color: var(--mat-sys-on-surface-variant);
+  min-width: 0;
+
+  &__icon {
+    font-size: 1.125rem;
+    line-height: 1;
+    color: var(--mat-sys-on-surface-variant);
+    flex-shrink: 0;
+  }
+
+  &__text {
+    @include text-truncate;
+    max-width: 16.25rem;
+
+    &--mono {
+      font-family: $font-family-mono;
+      letter-spacing: 0.2px;
+    }
+  }
+
+  &__link {
+    @include cluster($spacing-xs);
+    color: var(--mat-sys-primary);
+    text-decoration: none;
+    font-weight: $font-weight-medium;
+    font-size: $type-body-sm-size;
+    transition: color 200ms ease;
+
+    &:hover {
+      color: var(--md-on-primary-fixed);
+      text-decoration: underline;
+    }
+  }
+}
+
+:host ::ng-deep .cd-card-grid blogsphere-details-card {
+  display: block;
+  height: 100%;
+}
+
+:host ::ng-deep .cd-card-grid .details-card {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+:host ::ng-deep .cd-card-grid .details-card__body {
+  flex: 1;
 }
 
 .cd-empty {

--- a/src/app/features/api-cluster/cluster-details/cluster-details.component.spec.ts
+++ b/src/app/features/api-cluster/cluster-details/cluster-details.component.spec.ts
@@ -1,4 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Store } from '@ngrx/store';
+import { of } from 'rxjs';
+import { BreadcrumbService } from 'xng-breadcrumb';
+import { MatDialog } from '@angular/material/dialog';
 
 import { ClusterDetailsComponent } from './cluster-details.component';
 
@@ -7,10 +13,27 @@ describe('ClusterDetailsComponent', () => {
   let fixture: ComponentFixture<ClusterDetailsComponent>;
 
   beforeEach(async () => {
+    const storeStub = {
+      select: () => of(null),
+      dispatch: () => undefined,
+    };
+
     await TestBed.configureTestingModule({
-      declarations: [ ClusterDetailsComponent ]
-    })
-    .compileComponents();
+      declarations: [ClusterDetailsComponent],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: { params: { id: 'test-cluster-id' } },
+          },
+        },
+        { provide: Store, useValue: storeStub },
+        { provide: BreadcrumbService, useValue: { set: () => undefined } },
+        { provide: Router, useValue: { navigate: () => Promise.resolve(true) } },
+        { provide: MatDialog, useValue: { open: () => ({ afterClosed: () => of(false) }) } },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
   });
 
   beforeEach(() => {

--- a/src/app/features/api-cluster/cluster-details/cluster-details.component.ts
+++ b/src/app/features/api-cluster/cluster-details/cluster-details.component.ts
@@ -10,7 +10,7 @@ import {
 } from 'src/app/state/api-cluster/api-cluster.selector';
 import { AppState } from 'src/app/store/app.state';
 import { BreadcrumbService } from 'xng-breadcrumb';
-import { ButtonType, ButtonSize, BadgeType, ItemDeleteDialogData } from 'src/app/core/model/core';
+import { ButtonType, ButtonSize, ItemDeleteDialogData } from 'src/app/core/model/core';
 import { MatDialog } from '@angular/material/dialog';
 import { ItemDeleteDialogComponent } from 'src/app/shared/components/item-delete-dialog/item-delete-dialog.component';
 import { DateHelper } from 'src/app/shared/helpers/date.helper';
@@ -46,7 +46,6 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
 
   ButtonType = ButtonType;
   ButtonSize = ButtonSize;
-  BadgeType = BadgeType;
 
   constructor(
     private route: ActivatedRoute,

--- a/src/app/features/api-cluster/cluster-details/cluster-details.module.ts
+++ b/src/app/features/api-cluster/cluster-details/cluster-details.module.ts
@@ -1,27 +1,29 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
 import { ClusterDetailsComponent } from './cluster-details.component';
 import { ButtonModule } from 'src/app/shared/components/button/button.module';
 import { AppMaterialModule } from 'src/app/app-material.module';
 import { LoaderModule } from 'src/app/shared/components/loader/loader.module';
-import { BadgeModule } from 'src/app/shared/components/badge/badge.module';
 import { PipesModule } from 'src/app/shared/pipes/pipes.module';
 import { TooltipModule } from 'src/app/shared/components/tooltip/tooltip.module';
-import { HeroHeaderModule } from 'src/app/shared/components/hero-header/hero-header.module';
 import { DetailsCardModule } from 'src/app/shared/components/details-card/details-card.module';
+import { PageHeroModule } from 'src/app/shared/components/page-hero/page-hero.module';
+import { StatTileModule } from 'src/app/shared/components/stat-tile/stat-tile.module';
 
 @NgModule({
   declarations: [ClusterDetailsComponent],
   imports: [
     CommonModule,
+    RouterModule,
     AppMaterialModule,
     ButtonModule,
     LoaderModule,
-    BadgeModule,
     PipesModule,
     TooltipModule,
-    HeroHeaderModule,
-    DetailsCardModule
+    DetailsCardModule,
+    PageHeroModule,
+    StatTileModule,
   ],
   exports: [ClusterDetailsComponent],
 })

--- a/src/app/features/api-routes/route-details/route-details.component.html
+++ b/src/app/features/api-routes/route-details/route-details.component.html
@@ -6,6 +6,7 @@
         <blogsphere-page-hero-avatar
           hero-avatar
           shape="circle"
+          size="small"
           icon="route"
           [isActive]="r.isActive"
           [isInactive]="!r.isActive"
@@ -55,7 +56,7 @@
       <!-- ───────── METRIC TILES ───────── -->
       <section class="row gutter-sm rd-grid-row" aria-label="Route metrics">
         <div class="col-6 col-md-3">
-          <blogsphere-stat-tile
+          <blogsphere-stat-tile [compact]="true"
             [tone]="r.isActive ? 'success' : 'warning'"
             [icon]="r.isActive ? 'toggle_on' : 'toggle_off'"
             [value]="r.isActive ? 'Active' : 'Inactive'"
@@ -64,7 +65,7 @@
         </div>
 
         <div class="col-6 col-md-3">
-          <blogsphere-stat-tile
+          <blogsphere-stat-tile [compact]="true"
             tone="info"
             icon="api"
             [value]="(r.methods || []).length"
@@ -73,7 +74,7 @@
         </div>
 
         <div class="col-6 col-md-3">
-          <blogsphere-stat-tile
+          <blogsphere-stat-tile [compact]="true"
             tone="primary"
             icon="view_list"
             [value]="(r.headers || []).length"
@@ -82,7 +83,7 @@
         </div>
 
         <div class="col-6 col-md-3">
-          <blogsphere-stat-tile
+          <blogsphere-stat-tile [compact]="true"
             tone="primary"
             icon="swap_horiz"
             [value]="(r.transforms || []).length"

--- a/src/app/features/api-routes/route-details/route-details.component.html
+++ b/src/app/features/api-routes/route-details/route-details.component.html
@@ -159,7 +159,7 @@
         </div>
       </div>
 
-      <div class="row rd-grid-row rd-panel-grid align-items-stretch">
+      <div class="row rd-grid-row rd-panel-grid align-items-stretch" role="region" aria-label="Headers and transforms">
         <!-- ───────── HEADERS ───────── -->
         <div class="col-12 col-lg-6">
           <blogsphere-section-panel

--- a/src/app/features/api-routes/route-details/route-details.component.scss
+++ b/src/app/features/api-routes/route-details/route-details.component.scss
@@ -4,12 +4,13 @@
 .rd {
   max-width: $container-max;
   margin: 0 auto;
-  padding: $spacing-md $spacing-lg $spacing-xl;
+  padding: $spacing-md $spacing-lg $spacing-2xl;
   @include flex-column;
   gap: $spacing-md;
 
   @include mobile-only {
-    padding: $spacing-sm $spacing-md $spacing-lg;
+    padding: $spacing-sm $spacing-md $spacing-xl;
+    gap: $spacing-sm;
   }
 }
 

--- a/src/app/features/api-routes/route-details/route-details.component.scss
+++ b/src/app/features/api-routes/route-details/route-details.component.scss
@@ -4,12 +4,12 @@
 .rd {
   max-width: $container-max;
   margin: 0 auto;
-  padding: $spacing-md $spacing-lg $spacing-2xl;
+  padding: $spacing-sm $spacing-md $spacing-lg;
   @include flex-column;
-  gap: $spacing-md;
+  gap: $spacing-sm;
 
   @include mobile-only {
-    padding: $spacing-sm $spacing-md $spacing-xl;
+    padding: $spacing-xs $spacing-sm $spacing-md;
     gap: $spacing-sm;
   }
 }
@@ -20,15 +20,15 @@
   &__path {
     @include cluster($spacing-xs);
     max-width: 100%;
-    margin: 0 0 $spacing-md;
-    font-size: $type-body-md-size;
+    margin: 0 0 $spacing-sm;
+    font-size: $type-body-sm-size;
     color: var(--mat-sys-on-surface-variant);
 
     @include mobile-only { justify-content: center; }
   }
 
   &__path-icon {
-    font-size: 1.125rem;
+    font-size: 1rem;
     line-height: 1;
     color: var(--mat-sys-on-surface-variant);
     flex-shrink: 0;
@@ -36,13 +36,13 @@
 
   &__path-code {
     font-family: $font-family-mono;
-    font-size: $type-body-lg-size;
+    font-size: $type-body-sm-size;
     font-weight: $font-weight-medium;
     color: var(--mat-sys-on-surface);
     background: var(--mat-sys-surface-container);
     border: 1px solid var(--mat-sys-outline-variant);
-    border-radius: $border-radius-md;
-    padding: 4px $spacing-sm;
+    border-radius: $border-radius-sm;
+    padding: 2px $spacing-xs;
     @include text-truncate;
     max-width: 100%;
   }
@@ -56,18 +56,18 @@
 .rd-hero-actions { @include cluster($spacing-sm); }
 
 .rd-hero-btn-icon {
-  font-size: 1.125rem;
+  font-size: 1rem;
   line-height: 1;
 }
 
 .rd-hero-contact-item {
   @include cluster($spacing-xs);
-  font-size: $type-body-sm-size;
+  font-size: $font-size-xs;
   color: var(--mat-sys-on-surface-variant);
   min-width: 0;
 
   &__icon {
-    font-size: 1.125rem;
+    font-size: 1rem;
     line-height: 1;
     color: var(--mat-sys-on-surface-variant);
     flex-shrink: 0;
@@ -90,7 +90,7 @@
     color: var(--mat-sys-primary);
     text-decoration: none;
     font-weight: $font-weight-medium;
-    font-size: $type-body-sm-size;
+    font-size: $font-size-xs;
     transition: color 200ms ease;
 
     &:hover {
@@ -120,12 +120,41 @@
   flex: 1;
 }
 
+:host ::ng-deep .rd .page-hero.page-hero--compact {
+  .page-hero__main--compact {
+    padding: $spacing-md $spacing-lg;
+    gap: $spacing-sm;
+
+    @include respond-to(xs) {
+      padding: $spacing-sm $spacing-md;
+    }
+  }
+
+  .page-hero__contact {
+    gap: $spacing-sm;
+    padding: $spacing-sm $spacing-lg;
+
+    @include respond-to(xs) {
+      padding: $spacing-sm $spacing-md;
+    }
+  }
+
+  .page-hero__name--sm {
+    @include heading(6);
+  }
+
+  .page-hero__subtitle {
+    @include font($font-size-xs, $font-weight-regular);
+    margin-top: 2px;
+  }
+}
+
 .rd-row-card {
   display: grid;
   grid-template-columns: auto 1fr auto;
   align-items: center;
-  gap: $spacing-md;
-  padding: $spacing-sm $spacing-md;
+  gap: $spacing-sm;
+  padding: $spacing-xs $spacing-sm;
   border: 1px solid var(--mat-sys-outline-variant);
   border-radius: $border-radius-lg;
   background: var(--mat-sys-surface-container-lowest);
@@ -144,15 +173,15 @@
 
   &__icon {
     @include flex-center;
-    width: 2.25rem;
-    height: 2.25rem;
+    width: 2rem;
+    height: 2rem;
     border-radius: $border-radius-md;
     background: var(--mat-sys-secondary-container);
     flex-shrink: 0;
     align-self: flex-start;
 
     .material-symbols-rounded {
-      font-size: 1.25rem;
+      font-size: 1.125rem;
       line-height: 1;
       color: var(--mat-sys-on-secondary-container);
     }
@@ -181,7 +210,7 @@
   &__head { @include cluster($spacing-sm); }
 
   &__name {
-    font-size: $type-body-lg-size;
+    font-size: $type-body-md-size;
     font-weight: $font-weight-medium;
     color: var(--mat-sys-on-surface);
     word-break: break-word;
@@ -222,13 +251,13 @@
 .rd-transform-card {
   &__pattern {
     font-family: $font-family-mono;
-    font-size: $type-body-md-size;
+    font-size: $type-body-sm-size;
     font-weight: $font-weight-medium;
     color: var(--mat-sys-on-surface);
     background: var(--mat-sys-surface-container);
     border: 1px solid var(--mat-sys-outline-variant);
-    border-radius: $border-radius-md;
-    padding: 5px $spacing-sm;
+    border-radius: $border-radius-sm;
+    padding: 3px $spacing-xs;
     word-break: break-all;
     min-width: 0;
   }

--- a/src/app/features/api-routes/route-details/route-details.component.ts
+++ b/src/app/features/api-routes/route-details/route-details.component.ts
@@ -10,7 +10,6 @@ import {
 } from 'src/app/state/api-route/api-route.selector';
 import { AppState } from 'src/app/store/app.state';
 import { BreadcrumbService } from 'xng-breadcrumb';
-import { InfoCardSize, InfoCardVariant } from 'src/app/shared/components/info-card';
 import { ButtonSize, ButtonType, ItemDeleteDialogData } from 'src/app/core/model/core';
 import { MatDialog } from '@angular/material/dialog';
 import { ItemDeleteDialogComponent } from 'src/app/shared/components/item-delete-dialog/item-delete-dialog.component';
@@ -36,8 +35,6 @@ export class RouteDetailsComponent implements OnInit, OnDestroy {
   private routeName: string;
   private destroy$: Subject<void> = new Subject<void>();
 
-  InfoCardVariant = InfoCardVariant;
-  InfoCardSize = InfoCardSize;
   ButtonType = ButtonType;
   ButtonSize = ButtonSize;
 

--- a/src/app/features/api-routes/route-details/route-details.module.ts
+++ b/src/app/features/api-routes/route-details/route-details.module.ts
@@ -4,7 +4,6 @@ import { RouteDetailsComponent } from './route-details.component';
 import { AppMaterialModule } from 'src/app/app-material.module';
 import { ButtonModule } from 'src/app/shared/components/button/button.module';
 import { LoaderModule } from 'src/app/shared/components/loader/loader.module';
-import { InfoCardModule } from 'src/app/shared/components/info-card';
 import { PipesModule } from 'src/app/shared/pipes/pipes.module';
 import { DetailsCardModule } from 'src/app/shared/components/details-card/details-card.module';
 import { ApiClusterModule } from '../../api-cluster/api-cluster.module';
@@ -23,7 +22,6 @@ import { MethodPillModule } from 'src/app/shared/components/method-pill/method-p
     AppMaterialModule,
     ButtonModule,
     LoaderModule,
-    InfoCardModule,
     PipesModule,
     DetailsCardModule,
     ApiClusterModule,

--- a/src/app/features/sidebar/sidebar.component.html
+++ b/src/app/features/sidebar/sidebar.component.html
@@ -18,7 +18,7 @@
   </header>
 
   @if (authUser$ | async; as authUser) {
-    <section class="sidenav__welcome px-lg mb-lg">
+    <section class="sidenav__welcome px-lg my-lg">
       <a
         class="sidenav__avatar sidenav__avatar-link"
         routerLink="/user-profile"
@@ -28,7 +28,7 @@
         {{ (authUser.fullName || authUser.email || '?') | slice : 0 : 1 | uppercase }}
       </a>
       <div class="sidenav__welcome-text">
-        <span class="sidenav__welcome-label">Welcome back</span>
+        <!-- <span class="sidenav__welcome-label">Welcome back</span> -->
         <span class="sidenav__welcome-name">{{ authUser.fullName || authUser.email }}</span>
         @if (authUser.role) {
           <span class="sidenav__welcome-role">{{ authUser.role }}</span>
@@ -46,13 +46,13 @@
         [collapsed]="isCollapsedRail"
         (navigate)="handleSidenavItemClick()"
       />
-      <blogsphere-sidebar-nav-link
+      <!-- <blogsphere-sidebar-nav-link
         link="/user-profile"
         icon="person"
         label="Account"
         [collapsed]="isCollapsedRail"
         (navigate)="handleSidenavItemClick()"
-      />
+      /> -->
       @if (canAccessSystemSettings$ | async) {
         <blogsphere-sidebar-nav-link
           link="/subscription"

--- a/src/app/features/sidebar/sidebar.component.scss
+++ b/src/app/features/sidebar/sidebar.component.scss
@@ -180,7 +180,7 @@
   &__footer {
     margin-top: auto;
     flex-shrink: 0;
-    border-top: 1px solid var(--mat-sys-outline-variant);
+    // border-top: 1px solid var(--mat-sys-outline-variant);
   }
 
   &__signout {

--- a/src/app/shared/components/stat-tile/stat-tile.component.html
+++ b/src/app/shared/components/stat-tile/stat-tile.component.html
@@ -1,4 +1,4 @@
-<div class="stat-tile" [ngClass]="'stat-tile--' + tone">
+<div class="stat-tile" [class.stat-tile--compact]="compact" [ngClass]="'stat-tile--' + tone">
   <span class="stat-tile__icon-tile">
     <span class="material-symbols-rounded" aria-hidden="true">{{ icon }}</span>
   </span>

--- a/src/app/shared/components/stat-tile/stat-tile.component.scss
+++ b/src/app/shared/components/stat-tile/stat-tile.component.scss
@@ -34,6 +34,11 @@
     transform: translateY(-2px);
   }
 
+  &--compact:hover {
+    box-shadow: 0 3px 10px rgba(0, 0, 0, 0.08);
+    transform: translateY(-1px);
+  }
+
   &--primary {
     --stat-tile-color: #{$color-primary};
     --stat-tile-bg: #{rgba($color-primary, 0.08)};
@@ -100,5 +105,40 @@
   &__caption {
     @include type(label-sm);
     color: var(--md-on-surface-variant);
+  }
+
+  // ── Compact density (detail pages) ─────────────────────────────
+  &--compact {
+    gap: $spacing-sm;
+    padding: $spacing-sm $spacing-md;
+
+    &::before {
+      top: $spacing-sm;
+      bottom: $spacing-sm;
+    }
+
+    .stat-tile__icon-tile {
+      width: 32px;
+      height: 32px;
+      border-radius: $border-radius-base;
+
+      .material-symbols-rounded {
+        font-size: 18px;
+      }
+    }
+
+    .stat-tile__num {
+      @include font($font-size-lg, $font-weight-bold, $line-height-tight);
+    }
+
+    .stat-tile__label {
+      @include font($font-size-xs, $font-weight-medium);
+      letter-spacing: 0.4px;
+      margin-top: 0;
+    }
+
+    .stat-tile__meta {
+      margin-top: 2px;
+    }
   }
 }

--- a/src/app/shared/components/stat-tile/stat-tile.component.ts
+++ b/src/app/shared/components/stat-tile/stat-tile.component.ts
@@ -23,6 +23,8 @@ export class StatTileComponent {
   @Input() value: string | number = '';
   @Input() label = '';
   @Input() tone: StatTileTone = 'primary';
+  /** Smaller padding, icon tile, and type — for dense detail pages. */
+  @Input() compact = false;
   @Input() delta?: StatTileDelta;
   @Input() caption?: string;
 


### PR DESCRIPTION
## Summary

- **Cluster details**: Replaced `blogsphere-hero-header` with `blogsphere-page-hero` (compact), `blogsphere-page-hero-avatar` (hub icon, active state), hero body lines for load balancing and health path, Edit + JSON actions aligned with route-details, and a contact strip (unique id + **New route** link to `/api-route/route-setup`). Added a **stat-tile** metric row (Status, Load balancing, Health check, Destinations, Routes) using the same `row gutter-sm` / `col-*` grid as route-details. **Core configuration** and **Audit** sit in a two-column `cd-card-grid` on `md+`. JSON view uses a matching compact hero + Raw JSON card. Module: `PageHeroModule`, `StatTileModule`, `RouterModule`; removed `HeroHeaderModule` and `BadgeModule`.
- **Cluster SCSS**: Hero/contact/body patterns aligned with route-details; `::ng-deep` stretch rules for the KV card row; removed `.cd-stats` / `.cd-stat`.
- **Route details**: Matched shell padding and mobile gap to cluster page; `role="region"` + `aria-label` on the headers/transforms row; removed unused `InfoCardModule` / `InfoCard*` from component and module.
- **Tests**: `cluster-details.component.spec.ts` now provides `ActivatedRoute`, `Store`, `Router`, `MatDialog`, `BreadcrumbService`, and `NO_ERRORS_SCHEMA` so the component can instantiate.

## Test plan

- `npx ng build --configuration=production` — clean.
- `npx ng test --no-watch --browsers=ChromeHeadless --include='**/cluster-details.component.spec.ts' --include='**/route-details.component.spec.ts'` — clean.
- Chrome DevTools MCP: connected to running app; auth/guard kept detail URLs on dashboard in this environment; please spot-check **cluster** and **route** detail pages locally after login (1440 and ~500px width).

## Notes

- Does **not** change NgRx, table row builders, delete flows, or breadcrumb aliases.
- Merge after your review; I am not merging without approval.