### PR TITLE
feat: API route filtering, cluster/route delete, and UI polish

### DIFF
--- a/src/app/core/auth/auth.service.ts
+++ b/src/app/core/auth/auth.service.ts
@@ -51,13 +51,11 @@ export class AuthService {
       .logoffAndRevokeTokens()
       .pipe(
         catchError(err => {
-          console.error('Token revocation failed; attempting logout without revoke', err);
           return this.oidcSecurityService.logoff();
         })
       )
       .subscribe({
         error: error => {
-          console.error('Error logging out', error);
           this.oidcSecurityService.logoffLocal();
           window.location.href = '/';
         },
@@ -99,12 +97,10 @@ export class AuthService {
    */
   public checkIdServerSession(): Observable<boolean> {
     const checkUrl = new URL('/account/session/check', this.identityBaseUrl);
-    return this.http
-      .get(checkUrl.toString(), { withCredentials: true, observe: 'response' })
-      .pipe(
-        map(() => true),
-        catchError(() => of(false))
-      );
+    return this.http.get(checkUrl.toString(), { withCredentials: true, observe: 'response' }).pipe(
+      map(() => true),
+      catchError(() => of(false))
+    );
   }
 
   /**
@@ -154,8 +150,7 @@ export class AuthService {
   public hasValidRefreshToken(): boolean {
     try {
       const refreshToken =
-        localStorage.getItem('angular-auth-oidc-client_refresh_token') ||
-        sessionStorage.getItem('angular-auth-oidc-client_refresh_token');
+        localStorage.getItem('angular-auth-oidc-client_refresh_token') || sessionStorage.getItem('angular-auth-oidc-client_refresh_token');
       return !!refreshToken;
     } catch (error) {
       return false;

--- a/src/app/core/form-groups/api-route-form-group.ts
+++ b/src/app/core/form-groups/api-route-form-group.ts
@@ -21,6 +21,38 @@ export class ApiRouteFormGroupHelper {
       transforms: fb.array([]),
     });
   }
+
+  public static createApiRouteFilterFormGroup(fb: UntypedFormBuilder): UntypedFormGroup {
+   const group = fb.group({
+    cluster: [null],
+    status: [null],
+    rateLimiterPolicy: [null],
+    fromDate: [null],
+    toDate: [null],
+   });
+
+   group.get('fromDate').valueChanges.subscribe(value => {
+     if(value){
+      group.get('toDate').setValidators([Validators.required]);
+     }else{
+      group.get('toDate').setValidators([]);
+     }
+     group.get('toDate').markAsTouched();
+     group.get('toDate').updateValueAndValidity({ emitEvent: false });
+   });
+
+   group.get('toDate').valueChanges.subscribe(value => {
+    if(value){
+      group.get('fromDate').setValidators([Validators.required]);
+    }else{
+      group.get('fromDate').setValidators([]);
+    }
+    group.get('fromDate').markAsTouched();
+    group.get('fromDate').updateValueAndValidity({ emitEvent: false });
+   });
+
+   return group;
+  }
 }
 
 export class ApiRouteHeadersFormGroupHelper {

--- a/src/app/core/mappers/apigateway-mapping.ts
+++ b/src/app/core/mappers/apigateway-mapping.ts
@@ -1,0 +1,44 @@
+import { ApiClusterUpsertRequest } from "../model/api-cluster.model";
+import { ApiRouteUpsertRequest } from "../model/api-route.model";
+
+export class ApiGatewayMapping{
+    public static toClusterUpsertRequest(rawValue: any): ApiClusterUpsertRequest {
+        return {
+            clusterId: rawValue.clusterId,
+            loadBalancingPolicy: rawValue.loadBalancingPolicy,
+            healthCheckEnabled: rawValue.healthCheckEnabled?? false,
+            healthCheckPath: rawValue.healthCheckPath?? '',
+            healthCheckInterval: rawValue.healthCheckInterval?? 0,
+            healthCheckTimeout: rawValue.healthCheckTimeout?? 0,
+            destinations: rawValue.destinations.map(destination => ({
+                destinationId: destination.destinationId,
+                address: destination.address,
+                isActive: destination.isActive,
+            })),
+        };
+    }
+
+    public static toRouteUpsertRequest(rawValue: any): ApiRouteUpsertRequest {
+        return {
+          routeId: rawValue.routeId,
+          path: rawValue.path,
+          methods: rawValue.methods,
+          isActive: rawValue.isActive?? false,
+          rateLimiterPolicy: rawValue.rateLimiterPolicy,
+          clusterId: rawValue.clusterId,
+          headers: (rawValue.headers || []).map((header: { name: string; values: string; mode: string; isActive: boolean }) => ({
+            name: header.name,
+            values: (header.values || '')
+              .split(',')
+              .map((v: string) => v.trim())
+              .filter(Boolean),
+            mode: header.mode,
+            isActive: header.isActive?? false,
+          })),
+          transforms: (rawValue.transforms || []).map((transform: { pathPattern: string; isActive: boolean }) => ({
+            pathPattern: transform.pathPattern,
+            isActive: transform.isActive?? false,
+          })),
+        };
+    }
+}

--- a/src/app/features/api-cluster/api-cluster.component.html
+++ b/src/app/features/api-cluster/api-cluster.component.html
@@ -19,9 +19,10 @@
               [actionEnabled]="true"
               (visit)="onView($event)"
               (edit)="onEdit($event)"
+              (delete)="openDeleteDialog($event)"
               (pageChange)="onPageChange($event)"
-              [allowEdit]="allowEditOption$ | async"
-              [allowDelete]="false"
+              [allowEdit]="canEditorDeleteApiCluster$ | async"
+              [allowDelete]="canEditorDeleteApiCluster$ | async"
               (linkClick)="onLinkClick($event)"
             ></blogsphere-table>
           }

--- a/src/app/features/api-cluster/api-cluster.component.ts
+++ b/src/app/features/api-cluster/api-cluster.component.ts
@@ -1,11 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  NgZone,
-  OnDestroy,
-  OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, NgZone, OnDestroy, OnInit } from '@angular/core';
 import { fadeSlideInOut } from 'src/app/core/animations/fade-in-out';
 import { Store } from '@ngrx/store';
 import { AppState } from 'src/app/store/app.state';
@@ -26,18 +19,21 @@ import { TableColumnMap } from 'src/app/core/model/table-source';
 import { PageEvent } from '@angular/material/paginator';
 import { SearchLayoutService } from 'src/app/shared/components/search-layout/search-layout.service';
 import { Router } from '@angular/router';
-import { IconType } from 'src/app/core/model/core';
-import { AuthService } from 'src/app/core/auth/auth.service';
+import { IconType, ItemDeleteDialogData } from 'src/app/core/model/core';
 import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
 import { ApiClusterFormGroupHelper } from 'src/app/core/form-groups/api-cluster-form-group';
+import { selectHasAllPermissions } from 'src/app/state/auth/auth.selector';
+import { AppPermission } from 'src/app/core/auth/permissions.constants';
+import { MatDialog } from '@angular/material/dialog';
+import { ItemDeleteDialogComponent } from 'src/app/shared/components/item-delete-dialog/item-delete-dialog.component';
 
 @Component({
-    selector: 'blogsphere-api-cluster',
-    templateUrl: './api-cluster.component.html',
-    styleUrls: ['./api-cluster.component.scss'],
-    animations: [fadeSlideInOut],
-    changeDetection: ChangeDetectionStrategy.OnPush,
-    standalone: false
+  selector: 'blogsphere-api-cluster',
+  templateUrl: './api-cluster.component.html',
+  styleUrls: ['./api-cluster.component.scss'],
+  animations: [fadeSlideInOut],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: false,
 })
 export class ApiClusterComponent implements OnInit, OnDestroy {
   public apiClusters$ = this.store.select(selectApiClusters);
@@ -47,13 +43,7 @@ export class ApiClusterComponent implements OnInit, OnDestroy {
   public isApiClusterCountLoading$ = this.store.select(selectApiClusterCountLoading);
   public apiCusterDataSource = new MatTableDataSource<ApiClusterSummary>([]);
   public showEmptyStateButton: boolean;
-  public displayedColumns: string[] = [
-    'clusterName',
-    'loadBalancerName',
-    'status',
-    'routes',
-    'destinations',
-  ];
+  public displayedColumns: string[] = ['clusterName', 'loadBalancerName', 'status', 'routes', 'destinations'];
   public columnNameMap: TableColumnMap = {
     clusterName: {
       value: 'clusterId',
@@ -68,9 +58,12 @@ export class ApiClusterComponent implements OnInit, OnDestroy {
   public isFilterApplied: boolean;
   public isSearchApplied: boolean;
   public searchTerm: string;
-  public clusterFilterForm: UntypedFormGroup = ApiClusterFormGroupHelper.createApiClusterFilterFormGroup(
-    this.fb
+  public clusterFilterForm: UntypedFormGroup = ApiClusterFormGroupHelper.createApiClusterFilterFormGroup(this.fb);
+
+  public canEditorDeleteApiCluster$: Observable<boolean> = this.store.select(
+    selectHasAllPermissions([AppPermission.SYSTEM_VIEW_SETTINGS, AppPermission.SYSTEM_UPDATE_SETTINGS])
   );
+
   private currentSortField: string;
   private filters: { [key: string]: string } = null;
   private formDate: string = null;
@@ -86,8 +79,8 @@ export class ApiClusterComponent implements OnInit, OnDestroy {
     private zone: NgZone,
     private searchLayoutService: SearchLayoutService,
     private router: Router,
-    private auth: AuthService,
-    private fb: UntypedFormBuilder
+    private fb: UntypedFormBuilder,
+    private dialog: MatDialog
   ) {}
 
   ngOnInit(): void {
@@ -112,13 +105,7 @@ export class ApiClusterComponent implements OnInit, OnDestroy {
     this.destroy$.complete();
   }
 
-  public onPageChange(event: PageEvent): void {
-    console.log(event);
-  }
-
-  public get allowEditOption$(): Observable<boolean> {
-    return this.auth.isSuperAdmin() || this.auth.isAdmin();
-  }
+  public onPageChange(event: PageEvent): void {}
 
   public onEdit(event: ApiClusterSummary): void {
     this.router.navigate(['api-cluster', 'cluster-setup', event.id]);
@@ -130,6 +117,22 @@ export class ApiClusterComponent implements OnInit, OnDestroy {
 
   public onLinkClick(event: ApiClusterSummary): void {
     this.router.navigate(['api-cluster', 'details', event.id]);
+  }
+
+  public openDeleteDialog(event: ApiClusterSummary): void {
+    const dialogData: ItemDeleteDialogData = {
+      title: 'Delete ' + event.clusterId,
+      message: 'Are you sure you want to delete this API cluster?',
+    };
+    const dialogRef = this.dialog.open(ItemDeleteDialogComponent, {
+      width: '440px',
+      data: { dialogData },
+    });
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.store.dispatch(new ApiClusterActions.DeleteApiCluster({ id: event.id }));
+      }
+    });
   }
 
   private fetchApiCLusters(
@@ -201,8 +204,7 @@ export class ApiClusterComponent implements OnInit, OnDestroy {
           debounceTime(500),
           tap(text => {
             this.searchTerm = text;
-            this.isSearchApplied =
-              text.length > 3 || (text.length > 0 && text.length <= 3) ? true : false;
+            this.isSearchApplied = text.length > 3 || (text.length > 0 && text.length <= 3) ? true : false;
           })
         )
         .subscribe((text: string) => {
@@ -212,13 +214,7 @@ export class ApiClusterComponent implements OnInit, OnDestroy {
                 this.fetchApiClusterCount();
                 this.fetchApiCLusters(false, 10, 1, 'clusterId', text, this.currentSortField);
               } else {
-                this.fetchApiClusterCount(
-                  this.filters,
-                  text,
-                  'clusterId',
-                  this.formDate,
-                  this.toDate
-                );
+                this.fetchApiClusterCount(this.filters, text, 'clusterId', this.formDate, this.toDate);
                 this.fetchApiCLusters(
                   true,
                   10,
@@ -269,39 +265,16 @@ export class ApiClusterComponent implements OnInit, OnDestroy {
   }
 
   private changeSortMenu(): void {
-    this.searchLayoutService.sortChange$
-      .pipe(takeUntil(this.destroy$))
-      .subscribe((sortField: string) => {
-        this.currentSortField = sortField;
-        this.noChangeDetection(() => {
-          if (!this.isFilterApplied) {
-            console.log('no filter applied');
-            this.fetchApiCLusters(
-              !!this.searchTerm,
-              10,
-              1,
-              'clusterId',
-              this.searchTerm,
-              sortField
-            );
-          } else {
-            console.log('filter applied');
-            this.fetchApiCLusters(
-              true,
-              10,
-              1,
-              'clusterId',
-              this.searchTerm,
-              sortField,
-              'desc',
-              this.filters,
-              'createdAt',
-              this.formDate,
-              this.toDate
-            );
-          }
-        });
+    this.searchLayoutService.sortChange$.pipe(takeUntil(this.destroy$)).subscribe((sortField: string) => {
+      this.currentSortField = sortField;
+      this.noChangeDetection(() => {
+        if (!this.isFilterApplied) {
+          this.fetchApiCLusters(!!this.searchTerm, 10, 1, 'clusterId', this.searchTerm, sortField);
+        } else {
+          this.fetchApiCLusters(true, 10, 1, 'clusterId', this.searchTerm, sortField, 'desc', this.filters, 'createdAt', this.formDate, this.toDate);
+        }
       });
+    });
   }
 
   private applyFilter(): void {
@@ -312,7 +285,7 @@ export class ApiClusterComponent implements OnInit, OnDestroy {
       this.filters = this.clusterFilterForm.getRawValue();
       delete this.filters.fromDate;
       delete this.filters.toDate;
-      console.log(this.filters);
+
       this.noChangeDetection(() => {
         this.fetchApiCLusters(
           true,
@@ -327,14 +300,7 @@ export class ApiClusterComponent implements OnInit, OnDestroy {
           this.formDate,
           this.toDate
         );
-        this.fetchApiClusterCount(
-          this.filters,
-          this.searchTerm,
-          'clusterId',
-          this.formDate,
-          this.toDate,
-          'createdAt'
-        );
+        this.fetchApiClusterCount(this.filters, this.searchTerm, 'clusterId', this.formDate, this.toDate, 'createdAt');
       });
     });
   }
@@ -348,14 +314,7 @@ export class ApiClusterComponent implements OnInit, OnDestroy {
       this.filters = null;
 
       this.noChangeDetection(() => {
-        this.fetchApiCLusters(
-          !!this.searchTerm,
-          10,
-          1,
-          'clusterId',
-          this.searchTerm,
-          this.currentSortField
-        );
+        this.fetchApiCLusters(!!this.searchTerm, 10, 1, 'clusterId', this.searchTerm, this.currentSortField);
         this.fetchApiClusterCount(null, this.searchTerm, 'clusterId');
       });
     });

--- a/src/app/features/api-cluster/cluster-details/cluster-details.component.html
+++ b/src/app/features/api-cluster/cluster-details/cluster-details.component.html
@@ -27,13 +27,17 @@
         </div>
 
         <div hero-actions class="cd-hero-actions">
+          <blogsphere-button [type]="ButtonType.secondary" [size]="ButtonSize.small" (next)="toggleJsonView()">
+            <span class="material-symbols-rounded cd-hero-btn-icon">data_object</span>
+            JSON view
+          </blogsphere-button>
           <blogsphere-button [type]="ButtonType.secondary" [size]="ButtonSize.small" (next)="goToEdit()">
             <span class="material-symbols-rounded cd-hero-btn-icon">edit</span>
             Edit
           </blogsphere-button>
-          <blogsphere-button [type]="ButtonType.secondary" [size]="ButtonSize.small" (next)="toggleJsonView()">
-            <span class="material-symbols-rounded cd-hero-btn-icon">data_object</span>
-            JSON view
+          <blogsphere-button [type]="ButtonType.danger" [size]="ButtonSize.small" (next)="openDeleteDialog()">
+            <span class="material-symbols-rounded cd-hero-btn-icon">delete</span>
+            Delete
           </blogsphere-button>
         </div>
 
@@ -78,7 +82,7 @@
             label="Health check"
           ></blogsphere-stat-tile>
         </div>
-        <div class="col-6 col-md-4">
+        <div class="col-6 col-md-4 mt-lg">
           <blogsphere-stat-tile [compact]="true"
             tone="primary"
             icon="directions_run"
@@ -86,7 +90,7 @@
             label="Destinations"
           ></blogsphere-stat-tile>
         </div>
-        <div class="col-6 col-md-4">
+        <div class="col-6 col-md-4 mt-lg">
           <blogsphere-stat-tile [compact]="true"
             tone="primary"
             icon="route"
@@ -96,7 +100,7 @@
         </div>
       </section>
 
-      <div class="row cd-grid-row cd-card-grid align-items-stretch">
+      <div class="row cd-grid-row cd-card-grid align-items-stretch mt-lg">
         <div class="col-12 col-md-6">
           <blogsphere-details-card mode="keyValue" icon="settings" title="Core configuration">
             <blogsphere-kv-row label="Cluster id">{{ c.clusterId }}</blogsphere-kv-row>
@@ -170,6 +174,7 @@
       </div>
 
       <blogsphere-details-card
+        class="mt-lg"
         mode="table"
         icon="directions_run"
         title="Destinations"
@@ -177,9 +182,10 @@
         [flushBody]="true"
         [tableHeaders]="destinationsTableHeaders"
         [tableRows]="destinationsTableRows"
-        [compactTable]="true"
+        [compactTable]="false"
       ></blogsphere-details-card>
       <blogsphere-details-card
+        class="mt-lg"
         mode="table"
         icon="route"
         title="Routes"
@@ -187,7 +193,7 @@
         [flushBody]="true"
         [tableHeaders]="routesTableHeaders"
         [tableRows]="routesTableRows"
-        [compactTable]="true"
+        [compactTable]="false"
       >
         <div empty class="cd-empty">
           <span class="material-symbols-rounded cd-empty__icon">route</span>

--- a/src/app/features/api-cluster/cluster-details/cluster-details.component.ts
+++ b/src/app/features/api-cluster/cluster-details/cluster-details.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Store } from '@ngrx/store';
-import { filter, Subject, takeUntil } from 'rxjs';
+import { filter, Observable, Subject, takeUntil } from 'rxjs';
 import {
   selectApiCluster,
   selectApiClusterCommandResponse,
@@ -21,12 +21,14 @@ import {
   DetailsCardTableCell,
   DetailsCardTableRow,
 } from 'src/app/shared/components/details-card/details-card.model';
+import { selectHasAllPermissions } from 'src/app/state/auth/auth.selector';
+import { AppPermission } from 'src/app/core/auth/permissions.constants';
 
 @Component({
-    selector: 'blogsphere-cluster-details',
-    templateUrl: './cluster-details.component.html',
-    styleUrls: ['./cluster-details.component.scss'],
-    standalone: false
+  selector: 'blogsphere-cluster-details',
+  templateUrl: './cluster-details.component.html',
+  styleUrls: ['./cluster-details.component.scss'],
+  standalone: false,
 })
 export class ClusterDetailsComponent implements OnInit, OnDestroy {
   public clusterId: string = this.route.snapshot.params['id'];
@@ -40,12 +42,14 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
   public routesTableHeaders: string[] = ['Route id', 'Status', 'Methods', 'Path'];
   public destinationsTableRows: DetailsCardTableRow[] = [];
   public routesTableRows: DetailsCardTableRow[] = [];
+  public canEditOrDeleteApiCluster$: Observable<boolean> = this.store.select(selectHasAllPermissions([AppPermission.SYSTEM_VIEW_SETTINGS, AppPermission.SYSTEM_UPDATE_SETTINGS]));
 
   private clusterName: string;
   private destroy$: Subject<void> = new Subject<void>();
 
   ButtonType = ButtonType;
   ButtonSize = ButtonSize;
+
 
   constructor(
     private route: ActivatedRoute,
@@ -115,9 +119,7 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
     return DateHelper.formatDateToTimeAgo(date);
   }
 
-  private buildDestinationsTableRows(
-    destinations: any[] | null | undefined
-  ): DetailsCardTableRow[] {
+  private buildDestinationsTableRows(destinations: any[] | null | undefined): DetailsCardTableRow[] {
     return (destinations || []).map(d => {
       const idCell: DetailsCardTableCell = { text: d?.destinationId ?? '', variant: 'emphasis' };
       const statusCell: DetailsCardTableCell = { status: !!d?.isActive };
@@ -127,9 +129,7 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
     });
   }
 
-  private buildRoutesTableRows(
-    routes: ClusterRouteDetails[] | null | undefined
-  ): DetailsCardTableRow[] {
+  private buildRoutesTableRows(routes: ClusterRouteDetails[] | null | undefined): DetailsCardTableRow[] {
     return routes?.map(r => {
       const idCell: DetailsCardTableCell = {
         text: r?.routeId ?? '',

--- a/src/app/features/api-cluster/cluster-details/cluster-details.component.ts
+++ b/src/app/features/api-cluster/cluster-details/cluster-details.component.ts
@@ -88,7 +88,7 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
   }
 
   public goToRoutes(): void {
-    this.router.navigate(['api-route', 'route-setup']);
+    this.router.navigate(['api-route', 'route-setup'], { queryParams: { clusterId: this.clusterId } });
   }
 
   public openDeleteDialog(): void {
@@ -97,8 +97,7 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
       message: 'Are you sure you want to delete this API cluster?',
     };
     const dialogRef = this.dialog.open(ItemDeleteDialogComponent, {
-      width: '500px',
-      height: '250px',
+      width: '440px',
       data: {
         dialogData: dialogData,
       },
@@ -131,7 +130,7 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
   private buildRoutesTableRows(
     routes: ClusterRouteDetails[] | null | undefined
   ): DetailsCardTableRow[] {
-    return (routes || []).map(r => {
+    return routes?.map(r => {
       const idCell: DetailsCardTableCell = {
         text: r?.routeId ?? '',
         variant: 'emphasis',

--- a/src/app/features/api-cluster/cluster-setup/cluster-setup.component.ts
+++ b/src/app/features/api-cluster/cluster-setup/cluster-setup.component.ts
@@ -26,6 +26,7 @@ import * as RequestPageActions from 'src/app/state/request-page/request-page.act
 import { Subject, takeUntil } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
 import { BreadcrumbService } from 'xng-breadcrumb';
+import { ApiGatewayMapping } from 'src/app/core/mappers/apigateway-mapping';
 
 @Component({
     selector: 'blogsphere-cluster-setup',
@@ -91,8 +92,6 @@ export class ClusterSetupComponent implements OnInit, OnDestroy {
               isActive: destination.isActive,
             }))
           );
-
-          console.log(this.clusterForm.getRawValue());
         }
       });
     } else {
@@ -152,7 +151,7 @@ export class ClusterSetupComponent implements OnInit, OnDestroy {
       this.clusterForm.markAllAsTouched();
       this.isAnyDestinationProvided = false;
     } else {
-      const request: ApiClusterUpsertRequest = this.clusterForm.getRawValue();
+      const request: ApiClusterUpsertRequest = ApiGatewayMapping.toClusterUpsertRequest(this.clusterForm.getRawValue());
       this.store.dispatch(
         this.isEditMode
           ? new ApiClusterActions.UpdateApiCluster({ id: this.clusterId, apiCluster: request })

--- a/src/app/features/api-routes/api-routes.component.html
+++ b/src/app/features/api-routes/api-routes.component.html
@@ -1,8 +1,7 @@
 <div @fadeSlideInOut class="route-list__container">
-  <blogsphere-search-layout addButtonLabel="Create Api Route" filterLabel="API Route" [isFileterFormValid]="true">
+  <blogsphere-search-layout addButtonLabel="Create Api Route" filterLabel="Filter routes" [isFileterFormValid]="true">
     <ng-container>
-      <!-- <blogsphere-route-filter-form [filterForm]="routeFilterForm"></blogsphere-route-filter-form> -->
-      <p>Filter form will be added here</p>
+      <blogsphere-route-filter-form [filterForm]="routeFilterForm"></blogsphere-route-filter-form>
     </ng-container>
   </blogsphere-search-layout>
 
@@ -20,9 +19,10 @@
               [actionEnabled]="true"
               (visit)="onView($event)"
               (edit)="onEdit($event)"
+              (delete)="openDeleteDialog($event)"
               (pageChange)="onPageChange($event)"
-              [allowEdit]="allowEditOption$ | async"
-              [allowDelete]="false"
+              [allowEdit]="canEditOrDeleteApiRoute$ | async"
+              [allowDelete]="canEditOrDeleteApiRoute$ | async"
               (linkClick)="onLinkClick($event)"
             ></blogsphere-table>
           }

--- a/src/app/features/api-routes/api-routes.component.ts
+++ b/src/app/features/api-routes/api-routes.component.ts
@@ -1,13 +1,13 @@
 import { ChangeDetectorRef, Component, NgZone, OnDestroy, OnInit } from '@angular/core';
-import { UntypedFormBuilder, FormGroup } from '@angular/forms';
 import { Router } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { fadeSlideInOut } from 'src/app/core/animations/fade-in-out';
-import { AuthService } from 'src/app/core/auth/auth.service';
-import { ApiRouteSearchRequest, ApiRouteSummary } from 'src/app/core/model/api-route.model';
+import { ApiRouteCommandType, ApiRouteSearchRequest, ApiRouteSummary } from 'src/app/core/model/api-route.model';
 import { SearchLayoutService } from 'src/app/shared/components/search-layout/search-layout.service';
 import {
   selectApiRouteCountLoading,
+  selectApiRouteDeleting,
+  selectApiRouteCommandResponse,
   selectApiRoutes,
   selectApiRoutesLoading,
   selectApiRoutesPageMetadata,
@@ -17,18 +17,25 @@ import { AppState } from 'src/app/store/app.state';
 import { MatTableDataSource } from '@angular/material/table';
 import { TableColumnMap } from 'src/app/core/model/table-source';
 import { selectMobileViewState } from 'src/app/state/mobile-view/mobile-view.selector';
-import { debounceTime, map, Observable, Subject, takeUntil, tap } from 'rxjs';
-import { IconType } from 'src/app/core/model/core';
+import { debounceTime, filter, map, Observable, Subject, takeUntil, tap } from 'rxjs';
+import { IconType, ItemDeleteDialogData } from 'src/app/core/model/core';
 import * as ApiRouteActions from 'src/app/state/api-route/api-route.action';
+import * as RequestPageActions from 'src/app/state/request-page/request-page.action';
 import { PageEvent } from '@angular/material/paginator';
 import { CapitalizePipe } from 'src/app/shared/pipes/capitalize.pipe';
+import { AppPermission } from 'src/app/core/auth/permissions.constants';
+import { selectHasAllPermissions } from 'src/app/state/auth/auth.selector';
+import { ItemDeleteDialogComponent } from 'src/app/shared/components/item-delete-dialog/item-delete-dialog.component';
+import { MatDialog } from '@angular/material/dialog';
+import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
+import { ApiRouteFormGroupHelper } from 'src/app/core/form-groups/api-route-form-group';
 
 @Component({
-    selector: 'blogsphere-api-routes',
-    templateUrl: './api-routes.component.html',
-    styleUrls: ['./api-routes.component.scss'],
-    animations: [fadeSlideInOut],
-    standalone: false
+  selector: 'blogsphere-api-routes',
+  templateUrl: './api-routes.component.html',
+  styleUrls: ['./api-routes.component.scss'],
+  animations: [fadeSlideInOut],
+  standalone: false,
 })
 export class ApiRoutesComponent implements OnInit, OnDestroy {
   public apiRoutes$ = this.store.select(selectApiRoutes);
@@ -36,6 +43,8 @@ export class ApiRoutesComponent implements OnInit, OnDestroy {
   public totalApiRoutes$ = this.store.select(selectTotalApiRoutes);
   public isApiRoutesLoading$ = this.store.select(selectApiRoutesLoading);
   public isApiRouteCountLoading$ = this.store.select(selectApiRouteCountLoading);
+  public isRouteDeleting$ = this.store.select(selectApiRouteDeleting);
+  public isRouteDeleted$ = this.store.select(selectApiRouteCommandResponse);
   public apiRouteDataSource = new MatTableDataSource<ApiRouteSummary>([]);
   public showEmptyStateButton: boolean;
   public displayedColumns: string[] = ['routeName', 'path', 'rateLimitterPolicy', 'status'];
@@ -51,9 +60,10 @@ export class ApiRoutesComponent implements OnInit, OnDestroy {
   public isFilterApplied: boolean;
   public isSearchApplied: boolean;
   public searchTerm: string;
-  // public routeFilterForm: FormGroup = ApiRouteFormGroupHelper.createApiRouteFilterFormGroup(
-  //   this.fb
-  // );
+  public canEditOrDeleteApiRoute$: Observable<boolean> = this.store.select(
+    selectHasAllPermissions([AppPermission.SYSTEM_VIEW_SETTINGS, AppPermission.SYSTEM_UPDATE_SETTINGS])
+  );
+  public routeFilterForm: UntypedFormGroup = ApiRouteFormGroupHelper.createApiRouteFilterFormGroup(this.fb);
   private currentSortField: string;
   private filters: { [key: string]: string } = null;
   private formDate: string = null;
@@ -69,7 +79,7 @@ export class ApiRoutesComponent implements OnInit, OnDestroy {
     private store: Store<AppState>,
     private searchLayoutService: SearchLayoutService,
     private router: Router,
-    private auth: AuthService,
+    private dialog: MatDialog,
     private fb: UntypedFormBuilder
   ) {}
 
@@ -93,11 +103,18 @@ export class ApiRoutesComponent implements OnInit, OnDestroy {
         }
       });
 
+    this.isRouteDeleted$
+      .pipe(
+        takeUntil(this.destroy$),
+        filter(res => res && res.commandtType === ApiRouteCommandType.Delete)
+      )
+      .subscribe(res => this.handleRouteResponse(res.id));
+
     this.addApiRoute();
     this.performSearch();
     this.changeSortMenu();
-    // this.applyFilter();
-    // this.resetFilter();
+    this.applyFilter();
+    this.resetFilter();
   }
 
   ngOnDestroy(): void {
@@ -105,13 +122,7 @@ export class ApiRoutesComponent implements OnInit, OnDestroy {
     this.destroy$.complete();
   }
 
-  public onPageChange(event: PageEvent): void {
-    console.log(event);
-  }
-
-  public get allowEditOption$(): Observable<boolean> {
-    return this.auth.isSuperAdmin() || this.auth.isAdmin();
-  }
+  public onPageChange(event: PageEvent): void {}
 
   public onEdit(event: ApiRouteSummary): void {
     this.router.navigate(['api-route', 'route-setup', event.id]);
@@ -119,6 +130,22 @@ export class ApiRoutesComponent implements OnInit, OnDestroy {
 
   public onView(event: ApiRouteSummary): void {
     this.router.navigate(['api-route', 'details', event.id]);
+  }
+
+  public openDeleteDialog(event: ApiRouteSummary): void {
+    const dialogData: ItemDeleteDialogData = {
+      title: 'Delete ' + event.routeId,
+      message: 'Are you sure you want to delete this API route?',
+    };
+    const dialogRef = this.dialog.open(ItemDeleteDialogComponent, {
+      width: '440px',
+      data: { dialogData },
+    });
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.store.dispatch(new ApiRouteActions.DeleteApiRoute({ id: event.id }));
+      }
+    });
   }
 
   private fetchApiRoutes(
@@ -189,8 +216,7 @@ export class ApiRoutesComponent implements OnInit, OnDestroy {
           debounceTime(500),
           tap(text => {
             this.searchTerm = text;
-            this.isSearchApplied =
-              text.length > 3 || (text.length > 0 && text.length <= 3) ? true : false;
+            this.isSearchApplied = text.length > 3 || (text.length > 0 && text.length <= 3) ? true : false;
           })
         )
         .subscribe((text: string) => {
@@ -251,64 +277,65 @@ export class ApiRoutesComponent implements OnInit, OnDestroy {
   }
 
   private changeSortMenu(): void {
-    this.searchLayoutService.sortChange$
-      .pipe(takeUntil(this.destroy$))
-      .subscribe((sortField: string) => {
-        this.currentSortField = sortField;
-        this.noChangeDetection(() => {
-          if (!this.isFilterApplied) {
-            this.fetchApiRoutes(!!this.searchTerm, 10, 1, 'routeId', this.searchTerm, sortField);
-          } else {
-            this.fetchApiRoutes(
-              true,
-              10,
-              1,
-              'routeId',
-              this.searchTerm,
-              sortField,
-              'desc',
-              this.filters,
-              'createdAt',
-              this.formDate,
-              this.toDate
-            );
-          }
-        });
+    this.searchLayoutService.sortChange$.pipe(takeUntil(this.destroy$)).subscribe((sortField: string) => {
+      this.currentSortField = sortField;
+      this.noChangeDetection(() => {
+        if (!this.isFilterApplied) {
+          this.fetchApiRoutes(!!this.searchTerm, 10, 1, 'routeId', this.searchTerm, sortField);
+        } else {
+          this.fetchApiRoutes(true, 10, 1, 'routeId', this.searchTerm, sortField, 'desc', this.filters, 'createdAt', this.formDate, this.toDate);
+        }
       });
+    });
   }
 
   public onLinkClick(event: ApiRouteSummary): void {
     this.router.navigate(['api-route', 'details', event.id]);
   }
 
-  // private applyFilter(): void {
-  //   this.searchLayoutService.filter$.pipe(takeUntil(this.destroy$)).subscribe(() => {
-  //     this.isFilterApplied = true;
-  //     this.formDate = this.routeFilterForm.value.fromDate?.toISOString();
-  //     this.toDate = this.routeFilterForm.value.toDate?.toISOString();
-  //     this.filters = this.routeFilterForm.getRawValue();
-  //     delete this.filters.fromDate;
-  //     delete this.filters.toDate;
-  //     this.noChangeDetection(() => {
-  //       this.fetchApiRoutes(true, 10, 1, 'routeId', this.searchTerm, this.currentSortField, 'desc', this.filters, 'createdAt', this.formDate, this.toDate);
-  //       this.fetchApiRouteCount(this.filters, this.searchTerm, 'routeId', this.formDate, this.toDate, 'createdAt');
-  //     });
-  //   });
-  // }
+  private applyFilter(): void {
+    this.searchLayoutService.filter$.pipe(takeUntil(this.destroy$)).subscribe(() =>{
+      this.isFilterApplied = true;
+      this.formDate = this.routeFilterForm.value.fromDate?.toISOString();
+      this.toDate   = this.routeFilterForm.value.toDate?.toISOString();
+      this.filters  = this.routeFilterForm.getRawValue();
+      delete this.filters.formDate;
+      delete this.filters.toDate;
 
-  // private resetFilter(): void {
-  //   this.searchLayoutService.filterClear$.pipe(takeUntil(this.destroy$)).subscribe(() => {
-  //     this.routeFilterForm.reset();
-  //     this.isFilterApplied = false;
-  //     this.formDate = null;
-  //     this.toDate = null;
-  //     this.filters = null;
-  //     this.noChangeDetection(() => {
-  //       this.fetchApiRoutes(!!this.searchTerm, 10, 1, 'routeId', this.searchTerm, this.currentSortField);
-  //       this.fetchApiRouteCount(null, this.searchTerm, 'routeId');
-  //     });
-  //   });
-  // }
+      this.noChangeDetection(() => {
+        this.fetchApiRoutes(true, 10, 1, 'routeId,path', this.searchTerm, this.currentSortField, 'desc', this.filters, 'createdAt', this.formDate, this.toDate);
+      })
+      this.fetchApiRouteCount(this.filters, this.searchTerm, 'routeId,path', this.formDate, this.toDate, 'createdAt');
+    });
+  }
+
+  private resetFilter(): void {
+    this.searchLayoutService.filterClear$.pipe(takeUntil(this.destroy$)).subscribe(() => {
+      this.routeFilterForm.reset();
+      this.isFilterApplied = false;
+      this.formDate = null;
+      this.toDate = null;
+      this.filters = null;
+      this.noChangeDetection(() => {
+        this.fetchApiRoutes(!!this.searchTerm, 10, 1, 'routeId,path', this.searchTerm, this.currentSortField);
+        this.fetchApiRouteCount(null, this.searchTerm, 'routeId,path');
+      });
+    });
+  }
+
+  private handleRouteResponse(routeId: string): void {
+    console.log(routeId);
+    this.store.dispatch(
+      new RequestPageActions.RequestPageSet({
+        requestPage: 'apiRoute',
+        heading: `Successfully deleted route ${routeId}`,
+        subHeading: `The route has been successfully deleted. Continue managing your API routes below.`,
+        nextUrl: 'api-route',
+        nextButtonLabel: 'Manage routes',
+      })
+    );
+    this.router.navigate(['success']);
+  }
 
   private noChangeDetection(fn: Function): void {
     this.zone.runOutsideAngular(() => fn());

--- a/src/app/features/api-routes/api-routes.component.ts
+++ b/src/app/features/api-routes/api-routes.component.ts
@@ -29,6 +29,7 @@ import { ItemDeleteDialogComponent } from 'src/app/shared/components/item-delete
 import { MatDialog } from '@angular/material/dialog';
 import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
 import { ApiRouteFormGroupHelper } from 'src/app/core/form-groups/api-route-form-group';
+import { SnackbarService } from 'src/app/core/services/snackbar.service';
 
 @Component({
   selector: 'blogsphere-api-routes',
@@ -80,7 +81,8 @@ export class ApiRoutesComponent implements OnInit, OnDestroy {
     private searchLayoutService: SearchLayoutService,
     private router: Router,
     private dialog: MatDialog,
-    private fb: UntypedFormBuilder
+    private fb: UntypedFormBuilder,
+    private snackbar: SnackbarService
   ) {}
 
   ngOnInit(): void {
@@ -294,17 +296,29 @@ export class ApiRoutesComponent implements OnInit, OnDestroy {
   }
 
   private applyFilter(): void {
-    this.searchLayoutService.filter$.pipe(takeUntil(this.destroy$)).subscribe(() =>{
+    this.searchLayoutService.filter$.pipe(takeUntil(this.destroy$)).subscribe(() => {
       this.isFilterApplied = true;
       this.formDate = this.routeFilterForm.value.fromDate?.toISOString();
-      this.toDate   = this.routeFilterForm.value.toDate?.toISOString();
-      this.filters  = this.routeFilterForm.getRawValue();
+      this.toDate = this.routeFilterForm.value.toDate?.toISOString();
+      this.filters = this.routeFilterForm.getRawValue();
       delete this.filters.formDate;
       delete this.filters.toDate;
 
       this.noChangeDetection(() => {
-        this.fetchApiRoutes(true, 10, 1, 'routeId,path', this.searchTerm, this.currentSortField, 'desc', this.filters, 'createdAt', this.formDate, this.toDate);
-      })
+        this.fetchApiRoutes(
+          true,
+          10,
+          1,
+          'routeId,path',
+          this.searchTerm,
+          this.currentSortField,
+          'desc',
+          this.filters,
+          'createdAt',
+          this.formDate,
+          this.toDate
+        );
+      });
       this.fetchApiRouteCount(this.filters, this.searchTerm, 'routeId,path', this.formDate, this.toDate, 'createdAt');
     });
   }
@@ -324,17 +338,9 @@ export class ApiRoutesComponent implements OnInit, OnDestroy {
   }
 
   private handleRouteResponse(routeId: string): void {
-    console.log(routeId);
-    this.store.dispatch(
-      new RequestPageActions.RequestPageSet({
-        requestPage: 'apiRoute',
-        heading: `Successfully deleted route ${routeId}`,
-        subHeading: `The route has been successfully deleted. Continue managing your API routes below.`,
-        nextUrl: 'api-route',
-        nextButtonLabel: 'Manage routes',
-      })
-    );
-    this.router.navigate(['success']);
+    this.snackbar.showSuccess(`Route deleted successfully`);
+    this.store.dispatch(new ApiRouteActions.ResetDeleteSuccess());
+    this.useChangeDetection(() => (this.apiRouteDataSource.data = this.apiRouteDataSource.data.filter(route => route.id !== routeId)));
   }
 
   private noChangeDetection(fn: Function): void {

--- a/src/app/features/api-routes/api-routes.module.ts
+++ b/src/app/features/api-routes/api-routes.module.ts
@@ -20,6 +20,7 @@ import { ApiClusterEffects } from 'src/app/state/api-cluster/api-cluster.effect'
 import { API_CLUSTER_SERVICE_TOKEN } from 'src/app/core/services/interface/api-custer-service.interface';
 import { ApiClusterService } from 'src/app/core/services/api-cluster.service';
 import { RouteDetailsModule } from './route-details/route-details.module';
+import { RouteFilterFormModule } from './route-filter-form/route-filter-form.module';
 
 @NgModule({
   declarations: [ApiRoutesComponent],
@@ -37,6 +38,7 @@ import { RouteDetailsModule } from './route-details/route-details.module';
     NoContentLayoutModule,
     RouteSetupModule,
     RouteDetailsModule,
+    RouteFilterFormModule,
   ],
   providers: [
     {

--- a/src/app/features/api-routes/route-details/route-details.component.html
+++ b/src/app/features/api-routes/route-details/route-details.component.html
@@ -54,7 +54,7 @@
       </blogsphere-page-hero>
 
       <!-- ───────── METRIC TILES ───────── -->
-      <section class="row gutter-sm rd-grid-row" aria-label="Route metrics">
+      <section class="row gutter-sm rd-grid-row my-lg" aria-label="Route metrics">
         <div class="col-6 col-md-3">
           <blogsphere-stat-tile [compact]="true"
             [tone]="r.isActive ? 'success' : 'warning'"

--- a/src/app/features/api-routes/route-details/route-details.component.html
+++ b/src/app/features/api-routes/route-details/route-details.component.html
@@ -25,14 +25,20 @@
         </div>
 
         <div hero-actions class="rd-hero-actions">
-          <blogsphere-button [type]="ButtonType.secondary" [size]="ButtonSize.small" (next)="goToEdit()">
-            <span class="material-symbols-rounded rd-hero-btn-icon">edit</span>
-            Edit
-          </blogsphere-button>
           <blogsphere-button [type]="ButtonType.secondary" [size]="ButtonSize.small" (next)="toggleJsonView()">
             <span class="material-symbols-rounded rd-hero-btn-icon">data_object</span>
             JSON view
           </blogsphere-button>
+          @if (canEditOrDeleteApiRoute$ | async) {
+            <blogsphere-button [type]="ButtonType.secondary" [size]="ButtonSize.small" (next)="goToEdit()">
+              <span class="material-symbols-rounded rd-hero-btn-icon">edit</span>
+              Edit
+            </blogsphere-button>
+            <blogsphere-button [type]="ButtonType.danger" [size]="ButtonSize.small" (next)="openDeleteDialog()">
+              <span class="material-symbols-rounded rd-hero-btn-icon">delete</span>
+              Delete
+            </blogsphere-button>
+          }
         </div>
 
         <ng-container hero-contact>

--- a/src/app/features/api-routes/route-details/route-details.component.ts
+++ b/src/app/features/api-routes/route-details/route-details.component.ts
@@ -82,8 +82,7 @@ export class RouteDetailsComponent implements OnInit, OnDestroy {
       message: 'Are you sure you want to delete this API route?',
     };
     const dialogRef = this.dialog.open(ItemDeleteDialogComponent, {
-      width: '500px',
-      height: '250px',
+      width: '440px',
       data: {
         dialogData: dialogData,
       },

--- a/src/app/features/api-routes/route-details/route-details.component.ts
+++ b/src/app/features/api-routes/route-details/route-details.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Store } from '@ngrx/store';
-import { filter, Subject, takeUntil } from 'rxjs';
+import { filter, Observable, Subject, takeUntil } from 'rxjs';
 import {
   selectApiRoute,
   selectApiRouteCommandResponse,
@@ -17,6 +17,8 @@ import * as ApiRouteActions from 'src/app/state/api-route/api-route.action';
 import * as RequestPageActions from 'src/app/state/request-page/request-page.action';
 import { ApiRouteCommandType } from 'src/app/core/model/api-route.model';
 import { DateHelper } from 'src/app/shared/helpers/date.helper';
+import { AppPermission } from 'src/app/core/auth/permissions.constants';
+import { selectHasAllPermissions } from 'src/app/state/auth/auth.selector';
 
 @Component({
   selector: 'blogsphere-route-details',
@@ -31,7 +33,8 @@ export class RouteDetailsComponent implements OnInit, OnDestroy {
   public isRouteDeleting$ = this.store.select(selectApiRouteDeleting);
   public routeCommandResponse$ = this.store.select(selectApiRouteCommandResponse);
   public isJsonView: boolean = false;
-
+  public canEditOrDeleteApiRoute$: Observable<boolean> = this.store.select(selectHasAllPermissions([AppPermission.SYSTEM_VIEW_SETTINGS, AppPermission.SYSTEM_UPDATE_SETTINGS]));
+  
   private routeName: string;
   private destroy$: Subject<void> = new Subject<void>();
 

--- a/src/app/features/api-routes/route-filter-form/route-filter-form.component.html
+++ b/src/app/features/api-routes/route-filter-form/route-filter-form.component.html
@@ -1,0 +1,51 @@
+<div class="container" [formGroup]="filterForm">
+    <div class="row">
+        <div class="col-md-4">
+            <mat-form-field class="font-size-xl">
+                <mat-label>Cluster</mat-label>
+                <mat-select formControlName="cluster">
+                    @for(option of clusterOptions; track option.id)
+                    {
+                        <mat-option [value]="option.name">{{ option.name }}</mat-option>
+                    }
+                </mat-select>
+            </mat-form-field>
+        </div>
+        <div class="col-md-4">
+            <mat-form-field class="font-size-xl">
+                <mat-label>Route status</mat-label>
+                <mat-select formControlName="status">
+                    <mat-option value="Active">Active</mat-option>
+                    <mat-option value="Inactive">Inactive</mat-option>
+                </mat-select>
+            </mat-form-field>   
+        </div>
+    </div>
+    <div class="row mt-md">
+        <div class="col-12">
+            <h5>Filter by date</h5>
+        </div>
+        <div class="col-md-6">
+            <mat-form-field class="font-size-xl">
+                <mat-label>From date</mat-label>
+                <input 
+                    matInput
+                    [matDatepicker]="fromPicker"
+                    [min]="fromMinDate"
+                    [max]="fromMaxDate"
+                    formControlName="fromDate"
+                />
+                <mat-datepicker-toggle matSuffix [for]="fromPicker"></mat-datepicker-toggle>
+                <mat-datepicker #fromPicker></mat-datepicker>
+            </mat-form-field>
+        </div>
+        <div class="col-md-6">
+            <mat-form-field class="font-size-xl" appearance="outline">
+                <mat-label>To date</mat-label>
+                <input matInput [matDatepicker]="toPicker" [min]="toMinDate" [max]="toMaxDate" formControlName="toDate"/>
+                <mat-datepicker-toggle matSuffix [for]="toPicker"></mat-datepicker-toggle>
+                <mat-datepicker #toPicker></mat-datepicker>
+            </mat-form-field>
+        </div>
+    </div>
+</div>

--- a/src/app/features/api-routes/route-filter-form/route-filter-form.component.spec.ts
+++ b/src/app/features/api-routes/route-filter-form/route-filter-form.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RouteFilterFormComponent } from './route-filter-form.component';
+
+describe('RouteFilterFormComponent', () => {
+  let component: RouteFilterFormComponent;
+  let fixture: ComponentFixture<RouteFilterFormComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [RouteFilterFormComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(RouteFilterFormComponent);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/api-routes/route-filter-form/route-filter-form.component.ts
+++ b/src/app/features/api-routes/route-filter-form/route-filter-form.component.ts
@@ -1,0 +1,86 @@
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { UntypedFormGroup } from '@angular/forms';
+import { Store } from '@ngrx/store';
+import { RateLimiterPolicies } from 'src/app/core/model/api-route.model';
+import { selectApiClusters, selectTotalApiClusters } from 'src/app/state/api-cluster/api-cluster.selector';
+import { AppState } from 'src/app/store/app.state';
+import * as ApiClusterActions from 'src/app/state/api-cluster/api-custer.action';
+import { filter, map, Subject, switchMap, take, takeUntil } from 'rxjs';
+import moment from 'moment';
+
+@Component({
+  selector: 'blogsphere-route-filter-form',
+  standalone: false,
+  templateUrl: './route-filter-form.component.html',
+  styleUrl: './route-filter-form.component.scss',
+})
+export class RouteFilterFormComponent implements OnInit, OnDestroy {
+  @Input() filterForm: UntypedFormGroup;
+  public clusterOptions: { id: string; name: string }[] = [];
+  public rateLimiterPolicyOptions: RateLimiterPolicies[] = Object.values(RateLimiterPolicies);
+  public apiClusterCount = this.store.select(selectTotalApiClusters);
+  private destroy$ = new Subject<void>();
+
+  constructor(private store: Store<AppState>) {}
+
+  fromMinDate: Date = new Date(2000, 0, 1);
+  toMinDate: Date = new Date(2000, 0, 1);
+  fromMaxDate: Date = new Date();
+  toMaxDate: Date = new Date();
+
+  ngOnInit(): void {
+    this.setupClusterLists();
+    this.filterForm.valueChanges.subscribe(value => {
+      const { fromDate, toDate } = value;
+      const fromDateMoment = moment(fromDate);
+      const toDateMoment = moment(toDate);
+
+      if(fromDate && !toDate){
+        this.toMinDate=fromDateMoment.add(1, 'day').toDate();
+      }
+      if(toDate && fromDate && toDateMoment.isBefore(fromDateMoment)){
+        this.filterForm.get('toDate').reset();
+      }
+      if(toDate && fromDate && toDateMoment.isAfter(fromDateMoment))
+      {
+        this.toMinDate = fromDateMoment.add(1, 'day').toDate();
+      }
+    })
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  private setupClusterLists(): void {
+    this.store.dispatch(new ApiClusterActions.GetApiClusterCount({ isFilteredQuery: false }));
+    this.apiClusterCount
+    .pipe(
+      filter(count => count > 0),
+      take(1),
+      switchMap(count => {
+        this.store.dispatch(new ApiClusterActions.GetAllApiClusters({
+          isFilteredQuery: false,
+          pageIndex: 1,
+          pageSize: count,
+          matchPhraseField: '',
+          matchPhrase: '',
+          sortField: 'createdAt',
+          sortOrder: 'desc',
+        }));
+        return this.store.select(selectApiClusters)
+        .pipe(
+          filter((clusters): clusters is NonNullable<typeof clusters> => !!clusters && clusters.length === count),
+          take(1),
+          map(clusters => clusters.map(cluster => ({id: cluster.id, name: cluster.clusterId})))
+        );
+      }),
+      takeUntil(this.destroy$)
+    )
+    .subscribe(clusters => {
+      this.clusterOptions = clusters;
+    })
+  }
+}
+ 

--- a/src/app/features/api-routes/route-filter-form/route-filter-form.module.ts
+++ b/src/app/features/api-routes/route-filter-form/route-filter-form.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouteFilterFormComponent } from './route-filter-form.component';
+import { AppMaterialModule } from 'src/app/app-material.module';
+import { ReactiveFormsModule } from '@angular/forms';
+
+@NgModule({
+  declarations: [RouteFilterFormComponent],
+  imports: [CommonModule, AppMaterialModule, ReactiveFormsModule],
+  exports: [RouteFilterFormComponent],
+})
+export class RouteFilterFormModule {}

--- a/src/app/features/api-routes/route-setup/route-setup.component.html
+++ b/src/app/features/api-routes/route-setup/route-setup.component.html
@@ -174,12 +174,12 @@
               </table>
               @if (headers.length === 0) {
                 <div class="mt-md">
-                  <p class="text-muted font-size-lg">No headers configured. Click add to add header rules.</p>
+                  <p class="text-muted font-size-base">No headers configured. Click add to add header rules.</p>
                 </div>
               }
               @if (shouldShowHeaderFormErrors()) {
                 <div class="mt-md">
-                  <p class="text-error font-size-lg">Please fill all the headers with valid values</p>
+                  <p class="text-error font-size-base">Please fill all the headers with valid values</p>
                 </div>
               }
             </div>
@@ -269,17 +269,17 @@
               </table>
               @if (isAnyTransformProvided && transforms.length === 0) {
                 <div class="mt-md">
-                  <p class="text-muted font-size-lg">No transforms configured. Click add to add transform rules.</p>
+                  <p class="text-muted font-size-base">No transforms configured. Click add to add transform rules.</p>
                 </div>
               }
               @if (!isAnyTransformProvided) {
                 <div class="mt-md">
-                  <p class="text-error font-size-lg">Please select at least one transform</p>
+                  <p class="text-error font-size-base">Please select at least one transform</p>
                 </div>
               }
               @if (shouldShowTransformFormErrors()) {
                 <div class="mt-md">
-                  <p class="text-error font-size-lg">Please fill all the transforms with valid values</p>
+                  <p class="text-error font-size-base">Please fill all the transforms with valid values</p>
                 </div>
               }
             </div>

--- a/src/app/features/api-routes/route-setup/route-setup.component.ts
+++ b/src/app/features/api-routes/route-setup/route-setup.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnChanges, OnDestroy, OnInit } from '@angular/core';
 import { UntypedFormArray, UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Store } from '@ngrx/store';
@@ -29,21 +29,20 @@ import { AppState } from 'src/app/store/app.state';
 import * as ApiRouteActions from 'src/app/state/api-route/api-route.action';
 import * as RequestPageActions from 'src/app/state/request-page/request-page.action';
 import { filter, map, Subject, switchMap, take, takeUntil } from 'rxjs';
-import {
-  selectApiClusters,
-  selectTotalApiClusters,
-} from 'src/app/state/api-cluster/api-cluster.selector';
+import { selectApiClusters, selectTotalApiClusters } from 'src/app/state/api-cluster/api-cluster.selector';
 import * as ApiClusterActions from 'src/app/state/api-cluster/api-custer.action';
+import { ApiGatewayMapping } from 'src/app/core/mappers/apigateway-mapping';
 
 @Component({
-    selector: 'blogsphere-route-setup',
-    templateUrl: './route-setup.component.html',
-    styleUrls: ['./route-setup.component.scss'],
-    animations: [fadeSlideInOut],
-    standalone: false
+  selector: 'blogsphere-route-setup',
+  templateUrl: './route-setup.component.html',
+  styleUrls: ['./route-setup.component.scss'],
+  animations: [fadeSlideInOut],
+  standalone: false,
 })
 export class RouteSetupComponent implements OnInit, OnDestroy {
   public routeForm: UntypedFormGroup;
+  public clusterIdFromQuery: string;
   public routeId: string = this.route.snapshot.params['id'];
   public route$ = this.store.select(selectApiRoute);
   public isAnyHeaderProvided: boolean = true;
@@ -82,8 +81,8 @@ export class RouteSetupComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    this.setupClusterIdsSubscription();
     this.routeForm = ApiRouteFormGroupHelper.createApiRouteFormGroup(this.fb);
+    this.clusterIdFromQuery = this.route.snapshot.queryParams['clusterId'] ?? '';
 
     if (this.routeId) {
       this.loadRouteForEdit();
@@ -91,6 +90,7 @@ export class RouteSetupComponent implements OnInit, OnDestroy {
       this.resetFormForCreate();
     }
 
+    this.setupClusterIdsSubscription();
     this.subscribeToRouteCommandResponses();
   }
 
@@ -138,9 +138,7 @@ export class RouteSetupComponent implements OnInit, OnDestroy {
   }
 
   public shouldShowTransformFormErrors(): boolean {
-    return this.transforms.controls.some(
-      transform => (transform.touched || transform.dirty) && !transform.valid
-    );
+    return this.transforms.controls.some(transform => (transform.touched || transform.dirty) && !transform.valid);
   }
 
   public getErrorMessages(control: string): string {
@@ -149,13 +147,14 @@ export class RouteSetupComponent implements OnInit, OnDestroy {
 
   public onSubmit(): void {
     if (this.markFormTouchedIfInvalid()) return;
-    console.log(this.buildUpsertRequest());
-    this.dispatchUpsertRequest(this.buildUpsertRequest());
+    const request: ApiRouteUpsertRequest = ApiGatewayMapping.toRouteUpsertRequest(this.routeForm.getRawValue());
+    this.store.dispatch(
+      this.isEditMode ? new ApiRouteActions.UpdateApiRoute({ id: this.routeId, apiRoute: request }) : new ApiRouteActions.CreateApiRoute(request)
+    );
   }
 
   private setupClusterIdsSubscription(): void {
     this.store.dispatch(new ApiClusterActions.GetApiClusterCount({ isFilteredQuery: false }));
-
     this.apiClusterCount
       .pipe(
         filter(count => count > 0),
@@ -173,10 +172,7 @@ export class RouteSetupComponent implements OnInit, OnDestroy {
             })
           );
           return this.store.select(selectApiClusters).pipe(
-            filter(
-              (clusters): clusters is NonNullable<typeof clusters> =>
-                !!clusters && clusters.length === count
-            ),
+            filter((clusters): clusters is NonNullable<typeof clusters> => !!clusters && clusters.length === count),
             take(1),
             map(clusters => clusters.map(cluster => ({ id: cluster.id, name: cluster.clusterId })))
           );
@@ -185,7 +181,18 @@ export class RouteSetupComponent implements OnInit, OnDestroy {
       )
       .subscribe(clusters => {
         this.clusterIds = clusters.map(cluster => ({ id: cluster.id, name: cluster.name }));
+        this.applyClusterIdFromQuery();
       });
+  }
+
+  private applyClusterIdFromQuery(): void {
+    if (this.isEditMode || !this.clusterIdFromQuery) {
+      return;
+    }
+    const clusterExists = this.clusterIds.some(cluster => cluster.id === this.clusterIdFromQuery);
+    if (clusterExists) {
+      this.routeForm.patchValue({ clusterId: this.clusterIdFromQuery });
+    }
   }
 
   private loadRouteForEdit(): void {
@@ -228,9 +235,7 @@ export class RouteSetupComponent implements OnInit, OnDestroy {
   private patchTransformsFromRoute(route: ApiRoute): void {
     this.transforms.clear();
     (route.transforms || []).forEach(() => {
-      this.transforms.push(
-        ApiRouteTransformsFormGroupHelper.createRouteTransformFormGroup(this.fb)
-      );
+      this.transforms.push(ApiRouteTransformsFormGroupHelper.createRouteTransformFormGroup(this.fb));
     });
     this.transforms.patchValue(route.transforms || []);
   }
@@ -266,48 +271,12 @@ export class RouteSetupComponent implements OnInit, OnDestroy {
     return true;
   }
 
-  private buildUpsertRequest(): ApiRouteUpsertRequest {
-    const rawValue = this.routeForm.getRawValue();
-    return {
-      routeId: rawValue.routeId,
-      path: rawValue.path,
-      methods: rawValue.methods,
-      isActive: rawValue.isActive,
-      rateLimiterPolicy: rawValue.rateLimiterPolicy,
-      clusterId: rawValue.clusterId,
-      headers: (rawValue.headers || []).map(
-        (header: { name: string; values: string; mode: string; isActive: boolean }) => ({
-          name: header.name,
-          values: (header.values || '')
-            .split(',')
-            .map((v: string) => v.trim())
-            .filter(Boolean),
-          mode: header.mode,
-          isActive: header.isActive,
-        })
-      ),
-      transforms: rawValue.transforms || [],
-    };
-  }
-
-  private dispatchUpsertRequest(request: ApiRouteUpsertRequest): void {
-    this.store.dispatch(
-      this.isEditMode
-        ? new ApiRouteActions.UpdateApiRoute({ id: this.routeId, apiRoute: request })
-        : new ApiRouteActions.CreateApiRoute(request)
-    );
-  }
-
   private handleRouteResponse(response: ApiRouteCommandResponse): void {
     this.store.dispatch(
       new RequestPageActions.RequestPageSet({
         requestPage: 'apiRoute',
-        heading: `Successfully ${this.isEditMode ? 'updated' : 'created'} route ${
-          response.routeId
-        }`,
-        subHeading: `You can ${
-          this.isEditMode ? 'update' : 'create'
-        } more or get back to the api route page`,
+        heading: `Successfully ${this.isEditMode ? 'updated' : 'created'} route ${response.routeId}`,
+        subHeading: `You can ${this.isEditMode ? 'update' : 'create'} more or get back to the api route page`,
         previousUrl: 'api-route',
         nextUrl: this.isEditMode ? `api-route/route-setup/${response.id}` : 'api-route/route-setup',
         nextButtonLabel: this.isEditMode ? 'Edit again' : 'Add another route',

--- a/src/app/features/subscription/api-product-create-dialog/api-product-create-dialog.component.html
+++ b/src/app/features/subscription/api-product-create-dialog/api-product-create-dialog.component.html
@@ -27,7 +27,7 @@
         <textarea
           matInput
           type="text"
-          rows="8"
+          rows="3"
           formControlName="productDescription"
         ></textarea>
         <mat-error>{{ getErrorMessage('productDescription') }}</mat-error>

--- a/src/app/features/subscription/api-product-details/api-product-details.component.ts
+++ b/src/app/features/subscription/api-product-details/api-product-details.component.ts
@@ -190,8 +190,7 @@ export class ApiProductDetailsComponent implements OnInit, OnDestroy {
       message: 'Are you sure you want to delete this subscribed API?',
     };
     const dialogRef = this.dialog.open(ItemDeleteDialogComponent, {
-      width: '500px',
-      height: '250px',
+      width: '440px',
       data: {
         dialogData: dialogData,
       },
@@ -215,8 +214,7 @@ export class ApiProductDetailsComponent implements OnInit, OnDestroy {
       message: 'Are you sure you want to delete this subscription?',
     };
     const dialogRef = this.dialog.open(ItemDeleteDialogComponent, {
-      width: '500px',
-      height: '250px',
+      width: '440px',
       data: {
         dialogData: dialogData,
       },

--- a/src/app/features/subscription/subscribed-api-create-dialog/subscribed-api-create-dialog.component.html
+++ b/src/app/features/subscription/subscribed-api-create-dialog/subscribed-api-create-dialog.component.html
@@ -30,7 +30,7 @@
 
       <mat-form-field class="w-100">
         <mat-label>API description</mat-label>
-        <textarea matInput type="text" rows="8" formControlName="apiDescription"></textarea>
+        <textarea matInput type="text" rows="3" formControlName="apiDescription"></textarea>
         <mat-error>{{ getErrorMessage('apiDescription') }}</mat-error>
       </mat-form-field>
     </form>

--- a/src/app/features/subscription/subscription-create-dialog/subscription-create-dialog.component.html
+++ b/src/app/features/subscription/subscription-create-dialog/subscription-create-dialog.component.html
@@ -23,7 +23,7 @@
 
       <mat-form-field class="w-100">
         <mat-label>Subscription description</mat-label>
-        <textarea matInput type="text" rows="8" formControlName="subscriptionDescription"></textarea>
+        <textarea matInput type="text" rows="3" formControlName="subscriptionDescription"></textarea>
       </mat-form-field>
     </form>
   </div>

--- a/src/app/features/user-manager/management-user/management-user-details/management-user-details.component.html
+++ b/src/app/features/user-manager/management-user/management-user-details/management-user-details.component.html
@@ -72,6 +72,7 @@
             icon="shield_person"
             [value]="(u.roles || []).length"
             label="Assigned roles"
+            [compact]="true"
           ></blogsphere-stat-tile>
         </div>
 
@@ -81,6 +82,7 @@
             icon="vpn_key"
             [value]="(u.permissions || []).length"
             label="Permissions"
+            [compact]="true"
           ></blogsphere-stat-tile>
         </div>
 
@@ -90,6 +92,7 @@
             [icon]="u.isEmailConfirmed ? 'mark_email_read' : 'mark_email_unread'"
             [value]="u.isEmailConfirmed ? 'Verified' : 'Pending'"
             label="Email status"
+            [compact]="true"
           ></blogsphere-stat-tile>
         </div>
 
@@ -99,6 +102,7 @@
             [icon]="u.isPhoneNumberConfirmed ? 'phone_enabled' : 'phone_disabled'"
             [value]="u.isPhoneNumberConfirmed ? 'Verified' : 'Pending'"
             label="Phone status"
+            [compact]="true"
           ></blogsphere-stat-tile>
         </div>
       </section>

--- a/src/app/shared/components/details-card/details-card.component.scss
+++ b/src/app/shared/components/details-card/details-card.component.scss
@@ -79,13 +79,13 @@
     min-width: 0;
 
     thead th {
-      padding: $spacing-sm $spacing-lg;
-      font-size: $font-size-lg;
+      padding: $spacing-lg $spacing-lg;
+      font-size: $font-size-sm;
     }
 
     tbody td {
-      padding: $spacing-sm $spacing-lg;
-      font-size: $font-size-lg;
+      padding: $spacing-lg $spacing-lg;
+      font-size: $font-size-sm;
     }
   }
 
@@ -93,7 +93,7 @@
     background: $color-background-tertiary;
 
     th {
-      @include font($font-size-lg, $font-weight-medium);
+      @include font($font-size-sm, $font-weight-medium);
       color: rgba($color-text-primary, 0.6);
       text-transform: uppercase;
       letter-spacing: 0.6px;
@@ -118,7 +118,7 @@
     }
 
     td {
-      @include font($font-size-xl, $font-weight-regular);
+      @include font($font-size-sm, $font-weight-regular);
       color: $color-text-primary;
       padding: $spacing-md $spacing-xl;
       vertical-align: middle;

--- a/src/app/shared/components/item-delete-dialog/item-delete-dialog.component.html
+++ b/src/app/shared/components/item-delete-dialog/item-delete-dialog.component.html
@@ -1,17 +1,30 @@
-<div class="dialog-container">
-  <div class="dialog-header">
-    <span class="material-symbols-outlined">info</span>
-    <h2 class="mt-md">{{ dialogData.title }}</h2>
+<div class="dialog-shell item-delete-dialog">
+  <div class="dialog-shell__header">
+    <div class="dialog-shell__heading">
+      <div class="item-delete-dialog__title-row">
+        <span class="material-symbols-outlined item-delete-dialog__icon" aria-hidden="true">warning</span>
+        <h2 class="dialog-title">{{ dialogData.title }}</h2>
+      </div>
+    </div>
   </div>
-  <div class="dialog-content">
-    <p class="dialog-content-message">{{ dialogData.message }}</p>
+
+  <div mat-dialog-content class="dialog-shell__body">
+    <p class="item-delete-dialog__message">{{ dialogData.message }}</p>
   </div>
-  <div class="dialog-actions">
-    <blogsphere-button [type]="ButtonType.warning" [size]="ButtonSize.small" (next)="cancelDelete()">
+
+  <div mat-dialog-actions class="dialog-shell__actions" align="end">
+    <div class="d-flex gap-sm">
+      <blogsphere-button
+      [type]="ButtonType.secondary"
+      [size]="ButtonSize.small"
+      [elevated]="false"
+      (next)="cancelDelete()"
+    >
       Cancel
     </blogsphere-button>
-    <blogsphere-button [type]="ButtonType.danger" (next)="deleteItem()" [size]="ButtonSize.small">
+    <blogsphere-button [type]="ButtonType.danger" [size]="ButtonSize.small" (next)="deleteItem()">
       Delete
     </blogsphere-button>
+    </div>
   </div>
 </div>

--- a/src/app/shared/components/item-delete-dialog/item-delete-dialog.component.scss
+++ b/src/app/shared/components/item-delete-dialog/item-delete-dialog.component.scss
@@ -1,25 +1,23 @@
 @use 'sass-utils/variables' as *;
 @use 'sass-utils/mixins' as *;
 
-.dialog-container {
-    height: 100%;
-    padding: $spacing-lg;
-    & .dialog-header {
-        display: flex;
-        align-items: center;
-        justify-content: start;
-        gap: $spacing-sm;
-        color: $gray-800;
-    }
-    & .dialog-content {
-        padding: $spacing-xl;
-        @include font(16px, $font-weight-regular, $line-height-normal);
-    }
-    & .dialog-actions {
-        margin-top: $spacing-xl;
-        @include flex-start;
-        justify-content: center;
-        column-gap: $spacing-xl;
-        text-transform: uppercase!important;
-    }
+.item-delete-dialog {
+  &__title-row {
+    display: flex;
+    align-items: center;
+    gap: $spacing-sm;
+    min-width: 0;
+  }
+
+  &__icon {
+    flex-shrink: 0;
+    font-size: 1.5rem;
+    color: var(--md-status-error);
+  }
+
+  &__message {
+    margin: 0;
+    @include type(body-md);
+    color: var(--mat-sys-on-surface-variant);
+  }
 }

--- a/src/app/shared/components/section-panel/section-panel.component.scss
+++ b/src/app/shared/components/section-panel/section-panel.component.scss
@@ -62,7 +62,7 @@
   }
 
   &__head-sub {
-    @include font($font-size-lg, $font-weight-regular);
+    @include font($font-size-sm, $font-weight-regular);
     color: rgba($color-text-primary, 0.55);
     margin: 4px 0 0;
   }

--- a/src/app/shared/components/stat-tile/stat-tile.component.html
+++ b/src/app/shared/components/stat-tile/stat-tile.component.html
@@ -6,15 +6,11 @@
     <span class="stat-tile__num">{{ value }}</span>
     <span class="stat-tile__label">{{ label }}</span>
 
-    <div *ngIf="delta || caption" class="stat-tile__meta">
-      <blogsphere-status-pill
-        *ngIf="delta"
-        [tone]="deltaPillTone"
-        [icon]="deltaIcon"
-        [label]="delta.value"
-        size="sm"
-      ></blogsphere-status-pill>
-      <span *ngIf="caption" class="stat-tile__caption">{{ caption }}</span>
-    </div>
+    @if (delta || caption) {
+      <div class="stat-tile__meta">
+        <blogsphere-status-pill [tone]="deltaPillTone" [icon]="deltaIcon" [label]="delta.value" size="sm"></blogsphere-status-pill>
+        <span class="stat-tile__caption">{{ caption }}</span>
+      </div>
+    }
   </div>
 </div>

--- a/src/app/shared/components/stat-tile/stat-tile.component.scss
+++ b/src/app/shared/components/stat-tile/stat-tile.component.scss
@@ -128,7 +128,7 @@
     }
 
     .stat-tile__num {
-      @include font($font-size-lg, $font-weight-bold, $line-height-tight);
+      @include font($font-size-sm, $font-weight-bold, $line-height-tight);
     }
 
     .stat-tile__label {

--- a/src/app/shared/components/table/table.component.ts
+++ b/src/app/shared/components/table/table.component.ts
@@ -1,14 +1,4 @@
-import {
-  Component,
-  ContentChild,
-  EventEmitter,
-  Input,
-  OnChanges,
-  OnInit,
-  Output,
-  SimpleChanges,
-  TemplateRef,
-} from '@angular/core';
+import { Component, ContentChild, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges, TemplateRef } from '@angular/core';
 import { PageEvent } from '@angular/material/paginator';
 import { MatTableDataSource } from '@angular/material/table';
 import { TableColumnMap, TableDataSource } from 'src/app/core/model/table-source';
@@ -16,10 +6,10 @@ import { PaginationMetaData } from 'src/app/core/model/pagination';
 import { BadgeType } from 'src/app/core/model/core';
 
 @Component({
-    selector: 'blogsphere-table',
-    templateUrl: './table.component.html',
-    styleUrls: ['./table.component.scss'],
-    standalone: false
+  selector: 'blogsphere-table',
+  templateUrl: './table.component.html',
+  styleUrls: ['./table.component.scss'],
+  standalone: false,
 })
 export class TableComponent implements OnInit, OnChanges {
   @Input('dataSource') tableDataSource: MatTableDataSource<TableDataSource>;
@@ -105,9 +95,7 @@ export class TableComponent implements OnInit, OnChanges {
     return this.columnMap[Object.keys(this.columnMap).find(k => k === column)].isLinkField;
   }
 
-  public slideToggle(event) {
-    console.log(event);
-  }
+  public slideToggle(event) {}
 
   public onLinkClick(item: TableDataSource): void {
     this.linkClick.emit(item);

--- a/src/app/state/error/error.effect.ts
+++ b/src/app/state/error/error.effect.ts
@@ -8,14 +8,17 @@ import { AppState } from 'src/app/store/app.state';
 
 @Injectable({ providedIn: 'root' })
 export class ErrorEffects {
-  constructor(private actions$: Actions, private router: Router, private store: Store<AppState>) {}
+  constructor(
+    private actions$: Actions,
+    private router: Router,
+    private store: Store<AppState>
+  ) {}
 
   navigateToErrorPage$ = createEffect(
     () =>
       this.actions$.pipe(
         ofType(SET_ERROR),
         tap(() => {
-          console.log('navigateToErrorPage$');
           this.router.navigate(['/error']);
         })
       ),

--- a/src/assets/styles/_angular-material-theme.scss
+++ b/src/assets/styles/_angular-material-theme.scss
@@ -427,7 +427,7 @@ mat-slide-toggle,
   flex: 1 1 auto;
   min-height: 0;
   max-height: none;
-  padding: $spacing-lg !important;
+  padding: $spacing-sm $spacing-lg !important;
   overflow-y: auto;
   scrollbar-width: thin;
 
@@ -448,8 +448,8 @@ mat-slide-toggle,
 }
 
 .mat-mdc-dialog-container .mat-mdc-dialog-actions {
-  padding: $spacing-md $spacing-lg $spacing-lg !important;
-  border-top: 1px solid var(--mat-sys-outline-variant);
+  padding: $spacing-2xl $spacing-lg $spacing-lg !important;
+  // border-top: 1px solid var(--mat-sys-outline-variant);
   flex: 0 0 auto;
 }
 

--- a/src/assets/styles/base/_prototype-utilities.scss
+++ b/src/assets/styles/base/_prototype-utilities.scss
@@ -366,7 +366,7 @@
     justify-content: space-between;
     gap: $spacing-md;
     padding: $spacing-lg;
-    border-bottom: 1px solid var(--mat-sys-outline-variant);
+    // border-bottom: 1px solid var(--mat-sys-outline-variant);
     flex: 0 0 auto;
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,4 +9,6 @@ if (environment.production) {
 }
 
 platformBrowserDynamic().bootstrapModule(AppModule, { applicationProviders: [provideZoneChangeDetection()], })
-  .catch(err => console.error(err));
+  .catch(err => 
+    console.error('Error initializing application', err)
+  );


### PR DESCRIPTION
## Summary

- Add `ApiGatewayMapping` to normalize cluster and route form payloads before upsert dispatch
- Wire the API routes filter panel (cluster, status, rate limiter, date range) into the search layout
- Enable permission-gated delete on API cluster and route list/detail views
- Unify delete dialogs on the shared `dialog-shell` pattern and tighten detail-page typography

## Changes

### Core / API Gateway
- New `ApiGatewayMapping` mapper for cluster and route upsert requests
- `ApiRouteFormGroupHelper.createApiRouteFilterFormGroup` with cross-field date validation
- Cluster/route setup components use mapper instead of raw `getRawValue()`

### API Routes
- New `RouteFilterFormComponent` module with cluster options from store
- List view: filter integration, delete dialog, permission-based edit/delete (`SYSTEM_VIEW_SETTINGS` / `SYSTEM_UPDATE_SETTINGS`)
- Route details delete dialog width aligned to 440px

### API Cluster
- List view: delete action with permission checks (replaces role-based `AuthService` checks)
- Details: delete button in hero, improved stat-tile spacing, non-compact destination/route tables
- Route setup deep link passes `clusterId` query param

### Shared UI & Styles
- `ItemDeleteDialogComponent` migrated to `dialog-shell` layout with warning icon
- Smaller typography in details cards, section panels, and compact stat tiles
- Dialog padding/border tweaks in Material theme and prototype utilities
- Subscription create dialogs: shorter description textareas (3 rows)
- User details: compact stat tiles for roles/permissions/email/phone
- Removed stray `console.log` calls in auth, error effects, table, and cluster/route list flows

## Notes

- Branch was created from `main` because work was uncommitted on the default branch
- Excluded accidental file `src/app/shared/components/details-card/Untitled` from commits
- No secrets or credential files were included

## Test plan

- [ ] API Routes list: open filter panel, apply cluster/status/policy/date filters, clear filters
- [ ] API Routes list: verify edit/delete visible only with correct permissions; delete confirms and refreshes list
- [ ] API Route setup (create/edit): submit with headers/transforms; confirm payload mapping
- [ ] API Cluster list: verify edit/delete permission gating and delete flow
- [ ] API Cluster details: delete, JSON view, edit, and "Add route" navigates with `clusterId`
- [ ] Delete dialogs render correctly (header, body, actions) at 440px width
- [ ] User/subscription dialogs: textarea height and stat tile compact layout look correct
- [ ] `ng build` passes